### PR TITLE
fix render position within processBlock

### DIFF
--- a/src/JC303.cpp
+++ b/src/JC303.cpp
@@ -411,6 +411,8 @@ void JC303::processBlock (juce::AudioBuffer<float>& buffer,
         const auto message = midiMetadata.getMessage();
         const auto messagePosition = static_cast<int>(message.getTimeStamp());
 
+        render(buffer, currentSample, messagePosition);
+
         if (message.isNoteOn())
         {
             open303Core.noteOn(message.getNoteNumber(), message.getVelocity(), 0);
@@ -428,7 +430,6 @@ void JC303::processBlock (juce::AudioBuffer<float>& buffer,
             continue;
         }
 
-        render(buffer, currentSample, messagePosition);
         currentSample = messagePosition;
     }
     


### PR DESCRIPTION
Suggesting a move of the call to `render` earlier in the `for` loop so that the note is set at the `messagePosition` for subsequent render calls. Without this there's an extra fill of the buffer up to the first midi message.
