### PR TITLE
feat: LFO modulation (and PWM) - inspired by SH-101 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,6 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
     echo "export PKG_CONFIG_LIBDIR=/usr/lib/x86_64-linux-gnu/pkgconfig" >> /etc/bash.bashrc; \
     else \
     echo "export CROSS_AMD64=0" >> /etc/bash.bashrc; \
-    echo "export PKG_CONFIG_LIBDIR=/usr/lib/x86_64-linux-gnu/pkgconfig" >> /etc/bash.bashrc; \
     fi
 
 # ------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,79 +1,148 @@
 # --------------------------------------------------------------
 # JC-303 Linux builder environment - Debian 11 (Bullseye)
-# 
+#
 # Why?
 # 1: Build binary release with broad Linux OS compatibility
 #    uses glibc 2.31 as base (Debian 11)
 # 2: Make use of CI/CD
-# 
+#
 # Debian 11 (Bullseye) + glibc 2.31 + Modern toolchain + All JUCE deps
 # Mounts jc303 project root → /jc303
-# 
+#
 # Build the image (once)
-# docker build --platform linux/amd64 -t jc303-linux-builder .
-# 
+# docker build -t jc303-linux-builder .
+#
 # Run – mounts current directory → /jc303
-# docker run -it --rm --platform linux/amd64 -v "$(pwd):/jc303" jc303-linux-builder
+# docker run -it --rm -v "$(pwd):/jc303" jc303-linux-builder
 # --------------------------------------------------------------
+# Base image is always Debian 11 (host type doesn't matter)
 FROM debian:11
 
-# Prevent interactive prompts during package installation
+ARG TARGETPLATFORM
 ENV DEBIAN_FRONTEND=noninteractive
 
-# 1. Install Kitware's CMake (3.22+)
+# ------------------------------------------------------------
+# 0. Install Kitware CMake (same for both architectures)
+# ------------------------------------------------------------
 RUN apt-get update && \
     apt-get install -y ca-certificates gpg wget && \
-    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --dearmor - > /usr/share/keyrings/kitware-archive-keyring.gpg && \
-    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' > /etc/apt/sources.list.d/kitware.list && \
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc \
+    | gpg --dearmor - > /usr/share/keyrings/kitware-archive-keyring.gpg && \
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] \
+    https://apt.kitware.com/ubuntu/ focal main' \
+    > /etc/apt/sources.list.d/kitware.list && \
     apt-get update && \
     apt-get install -y cmake && \
     cmake --version
-    
-# 1. Update system and install build essentials
+
+# ------------------------------------------------------------
+# 1. Universal native tools (always installed)
+# ------------------------------------------------------------
 RUN apt-get update && \
     apt-get install -y \
-        build-essential \
-        make \
-        cmake-latest \
-        git \
-        wget \
-        curl \
-        pkg-config \
-        ninja-build \
-        # Graphics libraries
-        libx11-dev \
-        libxext-dev \
-        libxrandr-dev \
-        libxinerama-dev \
-        libxcursor-dev \
-        libxi-dev \
-        libgl1-mesa-dev \
-        libglu1-mesa-dev \
-        libfreetype6-dev \
-        # Audio libraries
-        libasound2-dev \
-        libjack-jackd2-dev \
-        libsamplerate0-dev \
-        libsndfile1-dev \
-        # Network / utils
-        libcurl4-openssl-dev \
-        libavahi-client-dev \
-        # JUCE extras
-        libgtk-3-dev \
-        libwebkit2gtk-4.0-dev \
-        libxml2-dev \
-        libzip-dev \
-        libfftw3-dev \
-        libjpeg-dev \
-        libpng-dev \
-        libgif-dev \
-        librsvg2-dev \
-        libbz2-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    build-essential \
+    git \
+    wget \
+    curl \
+    pkg-config \
+    ninja-build \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# 3. Workdir = /jc303 (host mounted)
+# ------------------------------------------------------------
+# 2. Conditional: If ARM host → install amd64 cross-toolchain
+# ------------------------------------------------------------
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+    echo ">>> ARM64 HOST DETECTED — Installing cross environment"; \
+    dpkg --add-architecture amd64 && apt-get update && \
+    apt-get install -y \
+    gcc-x86-64-linux-gnu \
+    g++-x86-64-linux-gnu \
+    # Graphics
+    libx11-dev:amd64 \
+    libxext-dev:amd64 \
+    libxrandr-dev:amd64 \
+    libxinerama-dev:amd64 \
+    libxcursor-dev:amd64 \
+    libxi-dev:amd64 \
+    libgl1-mesa-dev:amd64 \
+    libglu1-mesa-dev:amd64 \
+    libfreetype6-dev:amd64 \
+    # Audio
+    libasound2-dev:amd64 \
+    libjack-jackd2-dev:amd64 \
+    libsamplerate0-dev:amd64 \
+    libsndfile1-dev:amd64 \
+    # Network / utils
+    libcurl4-openssl-dev:amd64 \
+    libavahi-client-dev:amd64 \
+    # JUCE extras
+    libgtk-3-dev:amd64 \
+    libwebkit2gtk-4.0-dev:amd64 \
+    libxml2-dev:amd64 \
+    libzip-dev:amd64 \
+    libfftw3-dev:amd64 \
+    libjpeg-dev:amd64 \
+    libpng-dev:amd64 \
+    libgif-dev:amd64 \
+    librsvg2-dev:amd64 \
+    libbz2-dev:amd64 ; \
+    else \
+    echo ">>> AMD64 HOST DETECTED — Installing native libs"; \
+    apt-get update && \
+    apt-get install -y \
+    libx11-dev \
+    libxext-dev \
+    libxrandr-dev \
+    libxinerama-dev \
+    libxcursor-dev \
+    libxi-dev \
+    libgl1-mesa-dev \
+    libglu1-mesa-dev \
+    libfreetype6-dev \
+    # Audio
+    libasound2-dev \
+    libjack-jackd2-dev \
+    libsamplerate0-dev \
+    libsndfile1-dev \
+    # Network / utils
+    libcurl4-openssl-dev \
+    libavahi-client-dev \
+    # JUCE extras
+    libgtk-3-dev \
+    libwebkit2gtk-4.0-dev \
+    libxml2-dev \
+    libzip-dev \
+    libfftw3-dev \
+    libjpeg-dev \
+    libpng-dev \
+    libgif-dev \
+    librsvg2-dev \
+    libbz2-dev ; \
+    fi \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# ------------------------------------------------------------
+# 3. If ARM host → set default cross toolchain environment
+# ------------------------------------------------------------
+ENV CC_x86_64="x86_64-linux-gnu-gcc"
+ENV CXX_x86_64="x86_64-linux-gnu-g++"
+
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+    echo "export CC=\"$CC_x86_64\""  >> /etc/bash.bashrc; \
+    echo "export CXX=\"$CXX_x86_64\"" >> /etc/bash.bashrc; \
+    echo "export CROSS_AMD64=1" >> /etc/bash.bashrc; \
+    echo "export PKG_CONFIG_LIBDIR=/usr/lib/x86_64-linux-gnu/pkgconfig" >> /etc/bash.bashrc; \
+    else \
+    echo "export CROSS_AMD64=0" >> /etc/bash.bashrc; \
+    echo "export PKG_CONFIG_LIBDIR=/usr/lib/x86_64-linux-gnu/pkgconfig" >> /etc/bash.bashrc; \
+    fi
+
+# ------------------------------------------------------------
+# 4. Workdir
+# ------------------------------------------------------------
 WORKDIR /jc303
 
-# 4. Default: interactive shell
+# ------------------------------------------------------------
+# 5. Default shell
+# ------------------------------------------------------------
 CMD ["/bin/bash"]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,8 @@ target_sources("${PROJECT_NAME}"
         dsp/open303/rosic_Open303.cpp
         dsp/open303/rosic_RealFunctions.cpp
         dsp/open303/rosic_TeeBeeFilter.cpp
-        
+        dsp/open303/dfl_LFO.cpp
+
         gui/${GUI_THEME}/Gui.cpp
 
         JC303.cpp

--- a/src/JC303.cpp
+++ b/src/JC303.cpp
@@ -83,9 +83,40 @@ JC303::JC303()
                                                         0.0f,
                                                         1.0f,
                                                         0.25f),
+            std::make_unique<juce::AudioParameterFloat> ("pulseWidth",
+                                                        "Pulse Width",
+                                                        0.0f,
+                                                        1.0f,
+                                                        0.5f),
             std::make_unique<juce::AudioParameterBool> ("switchModState",
                                                         "Switch Mod",
                                                         false),
+            // LFO parameters
+            std::make_unique<juce::AudioParameterInt> ("lfoWaveform",
+                                                        "LFO Wave",
+                                                        0,
+                                                        5,
+                                                        0),
+            std::make_unique<juce::AudioParameterFloat> ("lfoRate",
+                                                        "LFO Rate",
+                                                        0.0f,
+                                                        1.0f,
+                                                        0.25f),
+            std::make_unique<juce::AudioParameterFloat> ("lfoPitchDepth",
+                                                        "LFO Pitch",
+                                                        0.0f,
+                                                        1.0f,
+                                                        0.0f),
+            std::make_unique<juce::AudioParameterFloat> ("lfoPwmDepth",
+                                                        "LFO PWM",
+                                                        0.0f,
+                                                        1.0f,
+                                                        0.0f),
+            std::make_unique<juce::AudioParameterFloat> ("lfoFilterDepth",
+                                                        "LFO Filter",
+                                                        0.0f,
+                                                        1.0f,
+                                                        0.0f),
             // overdrive
             std::make_unique<juce::AudioParameterInt> ("overdriveModelIndex",
                                                         "Overdrive Model Index",
@@ -124,6 +155,13 @@ JC303::JC303()
     softAttack = parameters.getRawParameterValue("softAttack");
     slideTime = parameters.getRawParameterValue("slideTime");
     sqrDriver = parameters.getRawParameterValue("sqrDriver");
+    pulseWidth = parameters.getRawParameterValue("pulseWidth");
+    // LFO parameters
+    lfoWaveform = parameters.getRawParameterValue("lfoWaveform");
+    lfoRate = parameters.getRawParameterValue("lfoRate");
+    lfoPitchDepth = parameters.getRawParameterValue("lfoPitchDepth");
+    lfoPwmDepth = parameters.getRawParameterValue("lfoPwmDepth");
+    lfoFilterDepth = parameters.getRawParameterValue("lfoFilterDepth");
     // overdrive parameters
     overdriveModelIndex = parameters.getRawParameterValue("overdriveModelIndex");
     switchOverdriveState = parameters.getRawParameterValue("switchOverdriveState");
@@ -146,6 +184,13 @@ JC303::JC303()
     setParameter(SOFT_ATTACK, *softAttack);
     setParameter(SLIDE_TIME, *slideTime);
     setParameter(TANH_SHAPER_DRIVE, *sqrDriver);
+    setParameter(PULSE_WIDTH, *pulseWidth);
+    // LFO parameters
+    setParameter(LFO_WAVEFORM, *lfoWaveform);
+    setParameter(LFO_RATE, *lfoRate);
+    setParameter(LFO_PITCH_DEPTH, *lfoPitchDepth);
+    setParameter(LFO_PWM_DEPTH, *lfoPwmDepth);
+    setParameter(LFO_FILTER_DEPTH, *lfoFilterDepth);
     setParameter(OVERDRIVE_LEVEL, *overdriveLevel);
     setParameter(OVERDRIVE_DRY_WET, *overdriveDryWet);
     setParameter(OVERDRIVE_MODEL_INDEX, *overdriveModelIndex);
@@ -175,7 +220,14 @@ JC303::JC303()
     parameters.addParameterListener("softAttack", this);
     parameters.addParameterListener("slideTime", this);
     parameters.addParameterListener("sqrDriver", this);
+    parameters.addParameterListener("pulseWidth", this);
     parameters.addParameterListener("switchModState", this);
+    // LFO parameter listeners
+    parameters.addParameterListener("lfoWaveform", this);
+    parameters.addParameterListener("lfoRate", this);
+    parameters.addParameterListener("lfoPitchDepth", this);
+    parameters.addParameterListener("lfoPwmDepth", this);
+    parameters.addParameterListener("lfoFilterDepth", this);
     parameters.addParameterListener("overdriveLevel", this);
     parameters.addParameterListener("overdriveDryWet", this);
     parameters.addParameterListener("overdriveModelIndex", this);
@@ -198,7 +250,14 @@ JC303::~JC303()
     parameters.removeParameterListener("softAttack", this);
     parameters.removeParameterListener("slideTime", this);
     parameters.removeParameterListener("sqrDriver", this);
+    parameters.removeParameterListener("pulseWidth", this);
     parameters.removeParameterListener("switchModState", this);
+    // LFO parameter listeners
+    parameters.removeParameterListener("lfoWaveform", this);
+    parameters.removeParameterListener("lfoRate", this);
+    parameters.removeParameterListener("lfoPitchDepth", this);
+    parameters.removeParameterListener("lfoPwmDepth", this);
+    parameters.removeParameterListener("lfoFilterDepth", this);
     parameters.removeParameterListener("overdriveLevel", this);
     parameters.removeParameterListener("overdriveDryWet", this);
     parameters.removeParameterListener("overdriveModelIndex", this);
@@ -253,6 +312,25 @@ void JC303::parameterChanged(const juce::String& parameterID, float newValue)
     }
     else if (parameterID == "sqrDriver" && *switchModState) {
         setParameter(TANH_SHAPER_DRIVE, newValue);
+    }
+    else if (parameterID == "pulseWidth") {
+        setParameter(PULSE_WIDTH, newValue);
+    }
+    // LFO parameters
+    else if (parameterID == "lfoWaveform") {
+        setParameter(LFO_WAVEFORM, newValue);
+    }
+    else if (parameterID == "lfoRate") {
+        setParameter(LFO_RATE, newValue);
+    }
+    else if (parameterID == "lfoPitchDepth") {
+        setParameter(LFO_PITCH_DEPTH, newValue);
+    }
+    else if (parameterID == "lfoPwmDepth") {
+        setParameter(LFO_PWM_DEPTH, newValue);
+    }
+    else if (parameterID == "lfoFilterDepth") {
+        setParameter(LFO_FILTER_DEPTH, newValue);
     }
     else if (parameterID == "overdriveLevel") {
         setParameter(OVERDRIVE_LEVEL, newValue);
@@ -381,6 +459,39 @@ void JC303::setParameter (Open303Parameters index, float value)
             //linToLin(value, 0.0, 1.0,   0.0,     60.0)
             linToLin(value, 0.0, 1.0,   25.0,     80.0)
             //linToLin(value, 0.0, 1.0,   36.9,     90.0)
+        );
+        break;
+
+    case PULSE_WIDTH:
+        open303Core.setPulseWidth(
+            linToLin(value, 0.0, 1.0,   1.0,     50.0)
+        );
+        break;
+
+    // LFO parameters
+    case LFO_WAVEFORM:
+        open303Core.setLfoWaveform(static_cast<int>(value));
+        break;
+    case LFO_RATE:
+        // Map 0.0-1.0 to 0.1-20.0 Hz (logarithmic)
+        open303Core.setLfoRate(
+            linToExp(value, 0.0, 1.0, 0.1, 20.0)
+        );
+        break;
+    case LFO_PITCH_DEPTH:
+        // Map 0.0-1.0 to -12 to +12 semitones (bipolar)
+        open303Core.setLfoPitchDepth(
+            linToLin(value, 0.0, 1.0, -12.0, 12.0)
+        );
+        break;
+    case LFO_PWM_DEPTH:
+        // Direct mapping 0.0-1.0
+        open303Core.setLfoPwmDepth(value);
+        break;
+    case LFO_FILTER_DEPTH:
+        // Map 0.0-1.0 to -1.0 to +1.0 (bipolar)
+        open303Core.setLfoFilterDepth(
+            linToLin(value, 0.0, 1.0, -1.0, 1.0)
         );
         break;
 	}

--- a/src/JC303.h
+++ b/src/JC303.h
@@ -19,6 +19,7 @@ enum Open303Parameters
   DECAY,
   ACCENT,
   VOLUME,
+  PULSE_WIDTH,
   // MODs
   SWITCH_MOD,
   NORMAL_DECAY,
@@ -27,6 +28,12 @@ enum Open303Parameters
   SOFT_ATTACK,
   SLIDE_TIME,
   TANH_SHAPER_DRIVE,
+  // LFO
+  LFO_WAVEFORM,
+  LFO_RATE,
+  LFO_PITCH_DEPTH,
+  LFO_PWM_DEPTH,
+  LFO_FILTER_DEPTH,
   // Overdrive
   OVERDRIVE_SWITCH,
   OVERDRIVE_LEVEL,
@@ -122,6 +129,13 @@ private:
     std::atomic<float>* softAttack = nullptr;
     std::atomic<float>* slideTime = nullptr;
     std::atomic<float>* sqrDriver = nullptr;
+    std::atomic<float>* pulseWidth = nullptr;
+    // LFO
+    std::atomic<float>* lfoWaveform = nullptr;
+    std::atomic<float>* lfoRate = nullptr;
+    std::atomic<float>* lfoPitchDepth = nullptr;
+    std::atomic<float>* lfoPwmDepth = nullptr;
+    std::atomic<float>* lfoFilterDepth = nullptr;
     // overdrive
     std::atomic<float>* overdriveModelIndex = nullptr;
     std::atomic<float>* switchOverdriveState = nullptr;

--- a/src/dsp/open303/dfl_LFO.cpp
+++ b/src/dsp/open303/dfl_LFO.cpp
@@ -1,0 +1,104 @@
+#include "dfl_LFO.h"
+
+namespace dfl
+{
+
+  LFO::LFO()
+  {
+    sampleRate      = 44100.0;
+    rate            = 5.0;      // Default 5 Hz
+    phase           = 0.0;
+    waveform        = 0;        // Sine
+    sampleHoldValue = 0.0;
+    pinkCounter     = 0;
+    for(int i = 0; i < 7; i++)
+      pinkState[i] = 0.0;
+    updateIncrement();
+  }
+
+  LFO::~LFO()
+  {
+
+  }
+
+  void LFO::setSampleRate(double newSampleRate)
+  {
+    if(newSampleRate > 0.0)
+    {
+      sampleRate = newSampleRate;
+      updateIncrement();
+    }
+  }
+
+  void LFO::setRate(double newRate)
+  {
+    if(newRate >= 0.1 && newRate <= 1000.0)
+    {
+      rate = newRate;
+      updateIncrement();
+    }
+  }
+
+  void LFO::setWaveform(int newWaveform)
+  {
+    if(newWaveform >= 0 && newWaveform <= 5)
+    {
+      waveform = newWaveform;
+      // Reset sample & hold value when changing waveform
+      if(waveform == 4)  // Random S&H
+        sampleHoldValue = generateRandomValue();
+      // Reset pink noise state when changing to pink noise
+      if(waveform == 5)  // Pink Noise
+      {
+        pinkCounter = 0;
+        for(int i = 0; i < 7; i++)
+          pinkState[i] = 0.0;
+      }
+    }
+  }
+
+  void LFO::reset()
+  {
+    phase = 0.0;
+    if(waveform == 4)  // Random S&H
+      sampleHoldValue = generateRandomValue();
+  }
+
+  void LFO::updateIncrement()
+  {
+    increment = rate / sampleRate;
+  }
+
+  double LFO::generateRandomValue()
+  {
+    // Generate random value between 0.0 and +1.0 (unipolar)
+    return static_cast<double>(rand()) / static_cast<double>(RAND_MAX);
+  }
+
+  double LFO::generatePinkNoise()
+  {
+    // Paul Kellett's pink noise algorithm (1/f spectrum, band-limited)
+    // Uses 7 octaves of noise, each updated at different rates
+    // This creates a warmer, more natural-sounding noise than white noise
+
+    // Update counters at different rates (powers of 2)
+    pinkCounter++;
+
+    // Update state variables at different rates (octaves)
+    // generateRandomValue() now returns 0.0 to 1.0, so we scale appropriately
+    if (pinkCounter & 1)    pinkState[0] = generateRandomValue() * 0.5;
+    if (pinkCounter & 2)    pinkState[1] = generateRandomValue() * 0.25;
+    if (pinkCounter & 4)    pinkState[2] = generateRandomValue() * 0.125;
+    if (pinkCounter & 8)    pinkState[3] = generateRandomValue() * 0.0625;
+    if (pinkCounter & 16)   pinkState[4] = generateRandomValue() * 0.03125;
+    if (pinkCounter & 32)   pinkState[5] = generateRandomValue() * 0.015625;
+    if (pinkCounter & 64)   pinkState[6] = generateRandomValue() * 0.0078125;
+
+    // Sum all octaves - with unipolar input, this gives approximately 0.0 to 1.0 range
+    double output = pinkState[0] + pinkState[1] + pinkState[2] + pinkState[3] +
+                    pinkState[4] + pinkState[5] + pinkState[6];
+
+    return output;
+  }
+
+} // end namespace dfl

--- a/src/dsp/open303/dfl_LFO.h
+++ b/src/dsp/open303/dfl_LFO.h
@@ -1,0 +1,148 @@
+#ifndef dfl_LFO_h
+#define dfl_LFO_h
+
+#include "GlobalDefinitions.h"
+#include <cstdlib>
+#include <cmath>
+
+namespace dfl
+{
+
+  /**
+
+  Low Frequency Oscillator with multiple waveforms inspired by the Roland SH-101.
+  Provides sine, triangle, sawtooth, square, sample & hold random, and noise waveforms.
+  All waveforms output unipolar range: 0.0 to +1.0.
+
+  */
+
+  class LFO
+  {
+
+  public:
+
+    //---------------------------------------------------------------------------------------------
+    // construction/destruction:
+
+    /** Constructor. */
+    LFO();
+
+    /** Destructor. */
+    ~LFO();
+
+    //---------------------------------------------------------------------------------------------
+    // parameter settings:
+
+    /** Sets the sample rate (in Hz). */
+    void setSampleRate(double newSampleRate);
+
+    /** Sets the LFO rate/frequency (in Hz). */
+    void setRate(double newRate);
+
+    /** Sets the waveform type (0=Triangle, 1=Saw Up, 2=Saw Down, 3=Square, 4=Random S&H, 5=Noise/Pink). */
+    void setWaveform(int newWaveform);
+
+    //---------------------------------------------------------------------------------------------
+    // inquiry:
+
+    /** Returns the current LFO rate (in Hz). */
+    double getRate() const { return rate; }
+
+    /** Returns the current waveform type. */
+    int getWaveform() const { return waveform; }
+
+    //---------------------------------------------------------------------------------------------
+    // audio processing:
+
+    /** Calculates one output sample at a time. */
+    INLINE double getSample();
+
+    //---------------------------------------------------------------------------------------------
+    // others:
+
+    /** Resets the LFO phase to zero. */
+    void reset();
+
+  protected:
+
+    /** Updates the phase increment based on current rate and sample rate. */
+    void updateIncrement();
+
+    /** Generates a random value between -1.0 and +1.0. */
+    double generateRandomValue();
+
+    /** Generates pink noise using Paul Kellett algorithm (band-limited white noise). */
+    double generatePinkNoise();
+
+    double sampleRate;      // sample rate in Hz
+    double rate;            // LFO frequency in Hz
+    double phase;           // current phase (0.0 to 1.0)
+    double increment;       // phase increment per sample
+    int waveform;           // 0=Triangle, 1=Saw Up, 2=Saw Down, 3=Square, 4=Random, 5=Pink Noise
+    double sampleHoldValue; // stored random value for S&H waveform
+
+    // Pink noise state (Paul Kellett algorithm)
+    double pinkState[7];    // 7 octaves of pink noise state
+    int pinkCounter;        // counter for pink noise updates
+
+  };
+
+  //-----------------------------------------------------------------------------------------------
+  // inlined functions:
+
+  INLINE double LFO::getSample()
+  {
+    double output = 0.0;
+
+    switch(waveform)
+    {
+      case 0: // Triangle (unipolar)
+        // Unipolar triangle: 0.0 to +1.0
+        if(phase < 0.5)
+          output = 2.0 * phase;         // Rising: 0 to +1
+        else
+          output = 2.0 - 2.0 * phase;   // Falling: +1 to 0
+        break;
+
+      case 1: // Sawtooth Up (unipolar)
+        // Unipolar rising sawtooth: 0.0 to +1.0
+        output = phase;
+        break;
+
+      case 2: // Sawtooth Down (unipolar)
+        // Unipolar falling sawtooth: +1.0 to 0.0
+        output = 1.0 - phase;
+        break;
+
+      case 3: // Square (unipolar)
+        // Unipolar square: 0.0 or +1.0
+        output = (phase < 0.5) ? 1.0 : 0.0;
+        break;
+
+      case 4: // Random (Sample & Hold, unipolar)
+        // Generate new random value at phase wrap
+        if(phase < increment)  // Just wrapped around
+          sampleHoldValue = generateRandomValue();
+        output = sampleHoldValue;
+        break;
+
+      case 5: // Noise (pink noise, unipolar)
+        output = generatePinkNoise();
+        break;
+
+      default:
+        output = 0.0;
+        break;
+    }
+
+    // Advance phase
+    phase += increment;
+    if(phase >= 1.0)
+      phase -= 1.0;
+
+    return output;
+  }
+
+} // end namespace dfl
+
+#endif // dfl_LFO_h

--- a/src/dsp/open303/rosic_MipMappedWaveTable.cpp
+++ b/src/dsp/open303/rosic_MipMappedWaveTable.cpp
@@ -245,7 +245,7 @@ void MipMappedWaveTable::fillWithSquare303()
 {
   // generate the saw-wave:
   int    N  = tableLength;
-  double k  = 0.5;
+  double k  = symmetry;  // Use symmetry parameter for pulse width
   int    N1 = clip(roundToInt(k*(N-1)), 1, N-1);
   int    N2 = N-N1;
   double s1 = 1.0 / (N1-1);

--- a/src/dsp/open303/rosic_Open303.cpp
+++ b/src/dsp/open303/rosic_Open303.cpp
@@ -30,6 +30,12 @@ Open303::Open303()
   slideToNextNote  = false;
   idle             = true;
 
+  // Pulse width and LFO defaults
+  basePulseWidth   =    50.0;
+  lfoPitchDepth    =     0.0;
+  lfoPwmDepth      =     0.0;
+  lfoFilterDepth   =     0.0;
+
   setEnvMod(25.0);
 
   oscillator.setWaveTable1(&waveTable1);
@@ -83,6 +89,7 @@ Open303::~Open303()
 
 void Open303::setSampleRate(double newSampleRate)
 {
+  sampleRate = newSampleRate;
   mainEnv.setSampleRate         (       newSampleRate);
   ampEnv.setSampleRate          (       newSampleRate);
   pitchSlewLimiter.setSampleRate((float)newSampleRate);
@@ -90,6 +97,7 @@ void Open303::setSampleRate(double newSampleRate)
   rc1.setSampleRate(             (float)newSampleRate);
   rc2.setSampleRate(             (float)newSampleRate);
   sequencer.setSampleRate(              newSampleRate);
+  lfo.setSampleRate(                    newSampleRate);
 
   highpass2.setSampleRate     (         newSampleRate);
   allpass.setSampleRate       (         newSampleRate);

--- a/src/dsp/open303/rosic_Open303.h
+++ b/src/dsp/open303/rosic_Open303.h
@@ -11,8 +11,10 @@
 #include "rosic_LeakyIntegrator.h"
 #include "rosic_EllipticQuarterBandFilter.h"
 #include "rosic_AcidSequencer.h"
+#include "dfl_LFO.h"
 
 #include <list>
+using dfl::LFO;
 using namespace std; // for the noteList
 
 namespace rosic
@@ -45,9 +47,16 @@ namespace rosic
     /** Sets the sample-rate (in Hz). */
     void setSampleRate(double newSampleRate);
 
-    /** Sets up the waveform continuously between saw and square - the input should be in the range 
+    /** Sets up the waveform continuously between saw and square - the input should be in the range
     0...1 where 0 means pure saw and 1 means pure square. */
     void setWaveform(double newWaveform) { oscillator.setBlendFactor(newWaveform); }
+
+    /** Sets the pulse width for the square wave (1-50%). */
+    void setPulseWidth(double newPulseWidth)
+    {
+      basePulseWidth = newPulseWidth;
+      oscillator.setPulseWidth(newPulseWidth);
+    }
 
     /** Sets the master tuning frequency for note A4 (usually 440 Hz). */
     void setTuning(double newTuning) { tuning = newTuning; }
@@ -132,13 +141,30 @@ namespace rosic
     approximately 3-4 seconds.  */
     void setAmpDecay(double newAmpDecay) { ampEnv.setDecay(newAmpDecay); }
 
-    /** Sets the amplitudes envelope's release time (in milliseconds). On the normal 303, this 
+    /** Sets the amplitudes envelope's release time (in milliseconds). On the normal 303, this
     parameter was fixed to .....  */
-    void setAmpRelease(double newAmpRelease) 
-    { 
+    void setAmpRelease(double newAmpRelease)
+    {
       normalAmpRelease = newAmpRelease;
-      ampEnv.setRelease(newAmpRelease); 
+      ampEnv.setRelease(newAmpRelease);
     }
+
+    // LFO parameter settings:
+
+    /** Sets the LFO waveform (0=Triangle, 1=Saw Up, 2=Saw Down, 3=Square, 4=Random, 5=Pink Noise). */
+    void setLfoWaveform(int waveform) { lfo.setWaveform(waveform); }
+
+    /** Sets the LFO rate in Hz (0.1 to 1000.0). */
+    void setLfoRate(double rate) { lfo.setRate(rate); }
+
+    /** Sets the LFO pitch modulation depth in semitones (-12 to +12). */
+    void setLfoPitchDepth(double depth) { lfoPitchDepth = depth; }
+
+    /** Sets the LFO PWM modulation depth (0.0 to 1.0, bipolar oscillation around base PW). */
+    void setLfoPwmDepth(double depth) { lfoPwmDepth = depth; }
+
+    /** Sets the LFO filter modulation depth (-1.0 to +1.0, maps to +/- 2 octaves). */
+    void setLfoFilterDepth(double depth) { lfoFilterDepth = depth; }
 
     //-----------------------------------------------------------------------------------------------
     // inquiry:
@@ -250,6 +276,7 @@ namespace rosic
     BiquadFilter              notch;
     EllipticQuarterBandFilter antiAliasFilter;
     AcidSequencer             sequencer;
+    LFO                       lfo;
 
   protected:
 
@@ -308,6 +335,14 @@ namespace rosic
     bool   slideToNextNote;  // indicate that we need to slide to the next note in sequencer mode
     bool   idle;             // flag to indicate that we have currently nothing to do in getSample
 
+    // Pulse width
+    double basePulseWidth;   // base pulse width (before LFO modulation)
+
+    // LFO modulation depths
+    double lfoPitchDepth;    // LFO pitch modulation depth in semitones (-12 to +12)
+    double lfoPwmDepth;      // LFO PWM modulation depth (0.0 to 1.0)
+    double lfoFilterDepth;   // LFO filter modulation depth (-1.0 to +1.0)
+
     list<MidiNoteEvent> noteList;
 
   };
@@ -357,22 +392,58 @@ namespace rosic
       }
     }
 
+    // LFO modulation - only process if at least one depth is non-zero
+    double pitchModFactor = 1.0;
+    double lfoFilterMod = 0.0;
+
+    if (lfoPitchDepth != 0.0 || lfoPwmDepth != 0.0 || lfoFilterDepth != 0.0)
+    {
+      // Get LFO output (0.0 to +1.0 unipolar, convert to bipolar for modulation)
+      double lfoValue = lfo.getSample() * 2.0 - 1.0;  // Convert unipolar to bipolar
+
+      // Apply LFO pitch modulation (in semitones, converted to frequency multiplier)
+      if (lfoPitchDepth != 0.0)
+      {
+        double semitones = lfoValue * lfoPitchDepth;
+        pitchModFactor = pow(2.0, semitones / 12.0);
+      }
+
+      // Apply LFO PWM modulation (bipolar, oscillates around base PW)
+      if (lfoPwmDepth != 0.0)
+      {
+        // lfoValue goes -1 to +1, depth is 0-1 (percentage of range)
+        double pwmMod = lfoValue * lfoPwmDepth * 49.0;  // Max +/- 49% swing
+        double modulatedPulseWidth = basePulseWidth + pwmMod;
+        // Clamp to valid range (1% to 99%)
+        if (modulatedPulseWidth < 1.0) modulatedPulseWidth = 1.0;
+        if (modulatedPulseWidth > 99.0) modulatedPulseWidth = 99.0;
+        oscillator.setPulseWidth(modulatedPulseWidth);
+      }
+
+      // Apply LFO filter modulation (bipolar, in octaves)
+      if (lfoFilterDepth != 0.0)
+      {
+        lfoFilterMod = lfoValue * lfoFilterDepth * 2.0;  // +/- 2 octaves max
+      }
+    }
+
     // calculate instantaneous oscillator frequency and set up the oscillator:
-    double instFreq = pitchSlewLimiter.getSample(oscFreq);
+    // Apply pitch modulation AFTER slew limiter to prevent smoothing of audio-rate LFO
+    double instFreq = pitchSlewLimiter.getSample(oscFreq) * pitchModFactor;
     oscillator.setFrequency(instFreq*pitchWheelFactor);
     oscillator.calculateIncrement();
 
-    // calculate instantaneous cutoff frequency from the nominal cutoff and all its modifiers and 
+    // calculate instantaneous cutoff frequency from the nominal cutoff and all its modifiers and
     // set up the filter:
     double mainEnvOut = mainEnv.getSample();
     double tmp1       = n1 * rc1.getSample(mainEnvOut);
     double tmp2       = 0.0;
     if( accentGain > 0.0 )
       tmp2 = mainEnvOut;
-    tmp2 = n2 * rc2.getSample(tmp2);  
+    tmp2 = n2 * rc2.getSample(tmp2);
     tmp1 = envScaler * ( tmp1 - envOffset );  // seems not to work yet
     tmp2 = accentGain*tmp2;
-    double instCutoff = cutoff * pow(2.0, tmp1+tmp2);
+    double instCutoff = cutoff * pow(2.0, tmp1+tmp2+lfoFilterMod);
     filter.setCutoff(instCutoff);
 
     double ampEnvOut = ampEnv.getSample();


### PR DESCRIPTION
Adds a dedicated LFO module inspired by the Roland SH-101, featuring six waveform types: Triangle, Saw Up, Saw Down, Square, Sample & Hold (Random), and Pink Noise. The LFO range extends up to audio rate for aggressive FM-style timbres.

(needs GUI integration)

This update also introduces pulse width to the square oscillator (needs a knob in the GUI).
With bipolar LFO modulation, to sweep symmetrically around the base pulse width for classic animated PWM tones.

Future enhancement could be to apply the envelope to PW as well.
