### PR TITLE
feat: add Filter FM (Devilfish mod)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,8 @@ target_sources("${PROJECT_NAME}"
         dsp/open303/rosic_Open303.cpp
         dsp/open303/rosic_RealFunctions.cpp
         dsp/open303/rosic_TeeBeeFilter.cpp
-        
+        dsp/open303/dfl_DiodeLadderFilter.cpp
+
         gui/${GUI_THEME}/Gui.cpp
 
         JC303.cpp

--- a/src/dsp/open303/dfl_DiodeLadderFilter.cpp
+++ b/src/dsp/open303/dfl_DiodeLadderFilter.cpp
@@ -1,0 +1,62 @@
+#include "dfl_DiodeLadderFilter.h"
+using namespace dfl;
+
+//-------------------------------------------------------------------------------------------------
+// construction/destruction:
+
+DiodeLadderFilter::DiodeLadderFilter()
+{
+  cutoff              =  1000.0;
+  driveFactor         =     1.0;
+  drive               =     0.0;
+  passbandCompensation =    0.0;
+  resonance           =     0.0;
+  sampleRate          = 44100.0;
+  octaveMode          =    true;  // default to TB-303 style
+  K                   =     0.0;
+
+  // Initialize coefficients
+  alpha = 0.0;
+  alpha2 = 0.0;
+  G1 = G2 = G3 = G4 = 0.0;
+  beta1 = beta2 = beta3 = beta4 = 0.0;
+  delta1 = delta2 = delta3 = 0.0;
+  gamma1 = gamma2 = gamma3 = 0.0;
+  epsilon1 = epsilon2 = epsilon3 = 0.0;
+  SG1 = SG2 = SG3 = SG4 = 0.0;
+  GAMMA = 0.0;
+
+  calculateCoefficients();
+  reset();
+}
+
+DiodeLadderFilter::~DiodeLadderFilter()
+{
+}
+
+//-------------------------------------------------------------------------------------------------
+// parameter settings:
+
+void DiodeLadderFilter::setSampleRate(double newSampleRate)
+{
+  if( newSampleRate > 0.0 )
+    sampleRate = newSampleRate;
+  calculateCoefficients();
+}
+
+void DiodeLadderFilter::setInputDrive(double newDrive)
+{
+  drive = newDrive;
+  driveFactor = dB2amp(newDrive);
+}
+
+//-------------------------------------------------------------------------------------------------
+// others:
+
+void DiodeLadderFilter::reset()
+{
+  z1 = 0.0;
+  z2 = 0.0;
+  z3 = 0.0;
+  z4 = 0.0;
+}

--- a/src/dsp/open303/dfl_DiodeLadderFilter.cpp
+++ b/src/dsp/open303/dfl_DiodeLadderFilter.cpp
@@ -15,6 +15,11 @@ DiodeLadderFilter::DiodeLadderFilter()
   octaveMode          =    true;  // default to TB-303 style
   K                   =     0.0;
 
+  // DC blocker state
+  dcR = 0.999;
+  dcPrev = 0.0;
+  dcOut = 0.0;
+
   // Initialize coefficients
   alpha = 0.0;
   alpha2 = 0.0;
@@ -59,4 +64,6 @@ void DiodeLadderFilter::reset()
   z2 = 0.0;
   z3 = 0.0;
   z4 = 0.0;
+  dcPrev = 0.0;
+  dcOut = 0.0;
 }

--- a/src/dsp/open303/dfl_DiodeLadderFilter.cpp
+++ b/src/dsp/open303/dfl_DiodeLadderFilter.cpp
@@ -20,6 +20,10 @@ DiodeLadderFilter::DiodeLadderFilter()
   dcPrev = 0.0;
   dcOut = 0.0;
 
+  // Filter FM (Devilfish mod)
+  filterFmDepth = 0.0;    // Default: off
+  acCouplingState = 0.0;  // AC coupling HPF state
+
   // Initialize coefficients
   alpha = 0.0;
   alpha2 = 0.0;
@@ -66,4 +70,5 @@ void DiodeLadderFilter::reset()
   z4 = 0.0;
   dcPrev = 0.0;
   dcOut = 0.0;
+  acCouplingState = 0.0;  // Reset AC coupling filter
 }

--- a/src/dsp/open303/dfl_DiodeLadderFilter.h
+++ b/src/dsp/open303/dfl_DiodeLadderFilter.h
@@ -4,6 +4,7 @@
 // standard-library includes:
 #include <stdlib.h>
 #include <cmath>
+#include <algorithm>
 
 // rosic includes:
 #include "rosic_RealFunctions.h"
@@ -101,6 +102,13 @@ namespace dfl
     /** Sets whether the first pole is one octave above (TB-303 style ~18dB/oct slope). */
     void setOctaveMode(bool enabled) { octaveMode = enabled; }
 
+    /** Sets the Filter FM depth (0 to 1). Devilfish-style audio-rate cutoff modulation.
+     *  Uses AC-coupled input signal to modulate filter cutoff frequency. */
+    void setFilterFmDepth(double depth) { filterFmDepth = std::max(0.0, std::min(1.0, depth)); }
+
+    /** Returns the Filter FM depth. */
+    double getFilterFmDepth() const { return filterFmDepth; }
+
     //---------------------------------------------------------------------------------------------
     // inquiry:
 
@@ -182,6 +190,13 @@ namespace dfl
     // DC blocker state and coefficient
     double dcPrev, dcOut;
     double dcR;  // coefficient: exp(-2*PI*fc/sampleRate), fc ~5Hz
+
+    // Filter FM (Devilfish mod) - audio-rate cutoff modulation from input
+    // AC-coupled input signal modulates filter cutoff frequency
+    double filterFmDepth;                         // User parameter: 0 (off) to 1 (full)
+    double acCouplingState;                       // One-pole HPF state for AC coupling
+    static constexpr double acCouplingFreq = 20.0; // AC coupling corner frequency (Hz)
+    static constexpr double filterFmScale = 0.4;  // Scale factor for FM modulation depth
   };
 
   //-----------------------------------------------------------------------------------------------
@@ -311,6 +326,25 @@ namespace dfl
     // Input without compensation - compensation applied at output
     double input = in;
 
+    // -------------------------------------------------------------------------
+    // Filter FM (Devilfish mod): AC-coupled input modulates cutoff
+    // Uses one-pole HPF for AC coupling (~20Hz corner)
+    // -------------------------------------------------------------------------
+    double fmMod = 1.0;
+    if (filterFmDepth > 0.0) {
+      // One-pole HPF for AC coupling: y[n] = x[n] - x_lp[n]
+      // where x_lp is one-pole LPF output
+      double acAlpha = 2.0 * PI * acCouplingFreq / sampleRate;
+      acCouplingState += acAlpha * (input - acCouplingState);
+      double acCoupledInput = input - acCouplingState;  // HPF output = input - LPF output
+
+      // Modulate alpha coefficients based on AC-coupled input
+      fmMod = std::max(0.5, std::min(1.5, 1.0 + filterFmDepth * filterFmScale * acCoupledInput));
+    }
+
+    double alphaFM = alpha * fmMod;
+    double alpha2FM = alpha2 * fmMod;
+
     // Calculate feedback signals (S4 -> S3 -> S2 -> S1)
     double S4 = beta4 * z4;
     double S3 = beta3 * (z3 + S4 * delta3);
@@ -332,27 +366,27 @@ namespace dfl
 
     // 1st stage (optionally one octave above for TB-303 style slope)
     double xin = un * gamma1 + S2 + epsilon1 * S1;
-    double v = (a1 * xin - z1) * (octaveMode ? alpha2 : alpha);
+    double v = (a1 * xin - z1) * (octaveMode ? alpha2FM : alphaFM);
     double lp1 = v + z1;
     z1 = lp1 + v;
     lp1 = lp1 + stageNL(lp1, 0.1, 0.02);  // kicks in early, subtle
 
     // 2nd stage
     xin = lp1 * gamma2 + S3 + epsilon2 * S2;
-    v = (a2 * xin - z2) * alpha;
+    v = (a2 * xin - z2) * alphaFM;
     double lp2 = v + z2;
     z2 = lp2 + v;
     lp2 = lp2 + stageNL(lp2, 0.25, 0.03);  // medium threshold
 
     // 3rd stage
     xin = lp2 * gamma3 + S4 + epsilon3 * S3;
-    v = (a3 * xin - z3) * alpha;
+    v = (a3 * xin - z3) * alphaFM;
     double lp3 = v + z3;
     z3 = lp3 + v;
     lp3 = lp3 + stageNL(lp3, 0.4, 0.04);  // higher threshold
 
     // 4th stage
-    v = (a4 * lp3 - z4) * alpha;
+    v = (a4 * lp3 - z4) * alphaFM;
     double lp4 = v + z4;
     z4 = lp4 + v;
     lp4 = lp4 + stageNL(lp4, 0.55, 0.05);  // kicks in late, strongest

--- a/src/dsp/open303/dfl_DiodeLadderFilter.h
+++ b/src/dsp/open303/dfl_DiodeLadderFilter.h
@@ -8,19 +8,62 @@
 // rosic includes:
 #include "rosic_RealFunctions.h"
 
-// chowdsp includes:
-#include <math_approx/math_approx.hpp>
-
 namespace dfl
 {
 
   /**
-   * 4-pole diode ladder filter based on Will Pirkle's analysis.
+   * 4-pole diode ladder filter based on Will Pirkle's TPT analysis.
    * http://www.willpirkle.com/Downloads/AN-6DiodeLadderFilter.pdf
    *
    * This is an alternative to TeeBeeFilter with a different character.
    * The diode ladder has asymmetric clipping characteristics and a
    * different resonance behavior compared to the transistor ladder.
+   *
+   * TB-303 Nonlinearity Structure:
+   * ------------------------------
+   * Three nonlinearity points model the real diode ladder behavior:
+   *
+   * 1. diodeShape() - Input saturation
+   *    - Asymmetric: positive side saturates via exp(), negative ~linear
+   *    - Produces even harmonics, dynamic cutoff shift under drive
+   *    - Models the diode input pair asymmetry
+   *
+   * 2. fbShape() - Feedback path saturation (applied to SIGMA)
+   *    - Gentler than input, causes resonance collapse at high levels
+   *    - Creates the characteristic "chirp" on resonant sweeps
+   *    - Models the feedback diode clipping behavior
+   *
+   * 3. stageNL() - Per-stage asymmetry (additive on each LP output)
+   *    - Very small (~1.5%) cubic nonlinearity
+   *    - Adds grit and "hollowness" under strong resonance
+   *    - Models diode pair influence on each integrator stage
+   *
+   * All nonlinearities are monotonic and preserve TPT stability.
+   * They appear before the implicit solver, not inside the feedback loop.
+   *
+   * Signal Flow:
+   * ------------
+   *  Input ──┬───────────────────────────────────────────────────┐
+   *          │                                                   │
+   *          │  ┌─────────────────────────────────────────────┐  │
+   *          │  │              FEEDBACK PATH                  │  │
+   *          │  │  SIGMA = SG1*S1 + SG2*S2 + SG3*S3 + SG4*S4 │  │
+   *          │  │  SIGMA = fbShape(SIGMA)  <── (2) FB shaper  │  │
+   *          │  └─────────────────────────────────────────────┘  │
+   *          │                      │                            │
+   *          v                      v                            │
+   *       ┌──────────────────────────────────────┐               │
+   *       │  un = (input - K*SIGMA)/(1+K*GAMMA)  │               │
+   *       │  un = diodeShape(drive*un)  <── (1) Input shaper    │
+   *       └──────────────────────────────────────┘               │
+   *                         │                                    │
+   *          ┌──────────────┼──────────────┬──────────────┐      │
+   *          v              v              v              v      │
+   *       ┌─────┐       ┌─────┐        ┌─────┐        ┌─────┐   │
+   *       │ LP1 │──────>│ LP2 │───────>│ LP3 │───────>│ LP4 │───┘
+   *       │+stageNL     │+stageNL      │+stageNL      │+stageNL
+   *       └─────┘       └─────┘        └─────┘        └─────┘
+   *          (3)           (3)            (3)            (3)
    */
 
   class DiodeLadderFilter
@@ -85,8 +128,14 @@ namespace dfl
     /** Causes the filter to re-calculate the coefficients. */
     INLINE void calculateCoefficients();
 
-    /** Implements the waveshaping nonlinearity. */
-    INLINE double shape(double x);
+    /** Asymmetric diode-like waveshaping nonlinearity (input stage). */
+    INLINE double diodeShape(double x);
+
+    /** Feedback path saturation (resonance collapse / chirp). */
+    INLINE double fbShape(double x);
+
+    /** Small asymmetric nonlinearity for stage outputs (diode pair influence). */
+    INLINE double stageNL(double x, double threshold, double amount);
 
     /** Resets the internal state variables. */
     void reset();
@@ -124,6 +173,15 @@ namespace dfl
     double resonance;             // resonance parameter (0-1, pre-skewed by Open303)
     double sampleRate;
     bool   octaveMode;            // true = 1st pole one octave above (TB-303 style)
+
+    // Diode nonlinearity parameters
+    static constexpr double diodeSharp = 4.5;   // steepness of diode conduction
+    static constexpr double diodeKnee  = 0.10;  // diode knee voltage
+    static constexpr double nlAtten    = 0.2;   // input attenuation before NL (headroom for drive)
+
+    // DC blocker state and coefficient
+    double dcPrev, dcOut;
+    double dcR;  // coefficient: exp(-2*PI*fc/sampleRate), fc ~5Hz
   };
 
   //-----------------------------------------------------------------------------------------------
@@ -156,6 +214,9 @@ namespace dfl
 
   INLINE void DiodeLadderFilter::calculateCoefficients()
   {
+    // DC blocker coefficient: ~5Hz cutoff
+    dcR = exp(-2.0 * PI * 5.0 / sampleRate);
+
     // Bilinear transform calculations
     double wd = 2.0 * PI * cutoff;
     double T = 1.0 / sampleRate;
@@ -212,10 +273,37 @@ namespace dfl
     K = 17.0 * resonance;
   }
 
-  INLINE double DiodeLadderFilter::shape(double x)
+  INLINE double DiodeLadderFilter::diodeShape(double x)
   {
-    // Soft clipping - tanh approximation
-    return math_approx::tanh<7>(x);
+    // Asymmetric diode-like waveshaper
+    // Negative side: mostly linear (diode reverse bias)
+    if (x < 0.0)
+      return 0.98 * x;
+
+    // Positive side: exponential diode knee - saturates to ~1.0
+    // Small DC offset is intentional (diode forward voltage)
+    return 1.0 - exp(-diodeSharp * (x + diodeKnee));
+  }
+
+  INLINE double DiodeLadderFilter::fbShape(double x)
+  {
+    // Feedback saturation - gentler than input, causes resonance collapse/chirp
+    // Asymmetric: positive saturates, negative mostly linear
+    if (x >= 0.0)
+      return 1.0 - exp(-3.0 * x);  // softer saturation than input
+    else
+      return 0.9 * x;  // linear on negative side
+  }
+
+  INLINE double DiodeLadderFilter::stageNL(double x, double threshold, double amount)
+  {
+    // Per-stage asymmetry - models diode pair influence
+    // Soft-clipped cubic: x³/(1+x²) preserves character but can't runaway
+    // Each stage has different threshold and amount for variety
+    double driveNorm = drive / 9.0;  // 0dB→0, 9dB→1
+    double stageAmt = (driveNorm > threshold) ? (driveNorm - threshold) / (1.0 - threshold) : 0.0;
+    double x2 = x * x;
+    return amount * stageAmt * x * x2 / (1.0 + x2);
   }
 
   INLINE double DiodeLadderFilter::getSample(double in)
@@ -232,40 +320,51 @@ namespace dfl
     // SIGMA - weighted sum of feedback signals
     double SIGMA = SG1 * S1 + SG2 * S2 + SG3 * S3 + SG4 * S4;
 
+    // TB-303 style feedback saturation (resonance collapse / chirp)
+    SIGMA = fbShape(SIGMA);
+
     // Form input to the ladder (with feedback)
     double un = (input - K * SIGMA) / (1.0 + K * GAMMA);
 
-    // Apply input nonlinearity
-    un = shape(driveFactor * un);
+    // Apply input nonlinearity (diode saturation)
+    // nlAtten provides headroom - inputDrive pushes into saturation
+    un = diodeShape(nlAtten * driveFactor * un);
 
     // 1st stage (optionally one octave above for TB-303 style slope)
     double xin = un * gamma1 + S2 + epsilon1 * S1;
     double v = (a1 * xin - z1) * (octaveMode ? alpha2 : alpha);
-    double lp = v + z1;
-    z1 = lp + v;
+    double lp1 = v + z1;
+    z1 = lp1 + v;
+    lp1 = lp1 + stageNL(lp1, 0.1, 0.02);  // kicks in early, subtle
 
     // 2nd stage
-    xin = lp * gamma2 + S3 + epsilon2 * S2;
+    xin = lp1 * gamma2 + S3 + epsilon2 * S2;
     v = (a2 * xin - z2) * alpha;
-    lp = v + z2;
-    z2 = lp + v;
+    double lp2 = v + z2;
+    z2 = lp2 + v;
+    lp2 = lp2 + stageNL(lp2, 0.25, 0.03);  // medium threshold
 
     // 3rd stage
-    xin = lp * gamma3 + S4 + epsilon3 * S3;
+    xin = lp2 * gamma3 + S4 + epsilon3 * S3;
     v = (a3 * xin - z3) * alpha;
-    lp = v + z3;
-    z3 = lp + v;
+    double lp3 = v + z3;
+    z3 = lp3 + v;
+    lp3 = lp3 + stageNL(lp3, 0.4, 0.04);  // higher threshold
 
     // 4th stage
-    v = (a4 * lp - z4) * alpha;
-    lp = v + z4;
-    z4 = lp + v;
+    v = (a4 * lp3 - z4) * alpha;
+    double lp4 = v + z4;
+    z4 = lp4 + v;
+    lp4 = lp4 + stageNL(lp4, 0.55, 0.05);  // kicks in late, strongest
 
-    // Oberheim variations
-    // return c.mA * dU + c.mB * dLP1 + c.mC * dLP2 + c.mD * dLP3 +  c.mE * dLP4;
+    // Apply passband gain compensation at output
+    double out = lp4 * (1.0 + passbandCompensation * K);
 
-    // Apply passband gain compensation at output (keeps saturation independent of compensation)
-    return lp * (1.0 + passbandCompensation * K);
+    // DC blocker on final output
+    dcOut = dcR * (dcOut + out - dcPrev);
+    dcPrev = out;
+
+    return dcOut;
   }
 
 } // end namespace dfl

--- a/src/dsp/open303/dfl_DiodeLadderFilter.h
+++ b/src/dsp/open303/dfl_DiodeLadderFilter.h
@@ -1,0 +1,273 @@
+#ifndef dfl_DiodeLadderFilter_h
+#define dfl_DiodeLadderFilter_h
+
+// standard-library includes:
+#include <stdlib.h>
+#include <cmath>
+
+// rosic includes:
+#include "rosic_RealFunctions.h"
+
+// chowdsp includes:
+#include <math_approx/math_approx.hpp>
+
+namespace dfl
+{
+
+  /**
+   * 4-pole diode ladder filter based on Will Pirkle's analysis.
+   * http://www.willpirkle.com/Downloads/AN-6DiodeLadderFilter.pdf
+   *
+   * This is an alternative to TeeBeeFilter with a different character.
+   * The diode ladder has asymmetric clipping characteristics and a
+   * different resonance behavior compared to the transistor ladder.
+   */
+
+  class DiodeLadderFilter
+  {
+
+  public:
+
+    //---------------------------------------------------------------------------------------------
+    // construction/destruction:
+
+    /** Constructor. */
+    DiodeLadderFilter();
+
+    /** Destructor. */
+    ~DiodeLadderFilter();
+
+    //---------------------------------------------------------------------------------------------
+    // parameter settings:
+
+    /** Sets the sample-rate for this filter. */
+    void setSampleRate(double newSampleRate);
+
+    /** Sets the cutoff frequency for this filter. */
+    INLINE void setCutoff(double newCutoff, bool updateCoefficients = true);
+
+    /** Sets the resonance (0-1 range, pre-skewed by Open303). */
+    INLINE void setResonance(double newResonance, bool updateCoefficients = true);
+
+    /** Sets the input drive in decibels. */
+    void setInputDrive(double newDrive);
+
+    /** Sets the passband gain compensation amount (0.0 = none, 1.0 = full compensation). */
+    void setPassbandCompensation(double newCompensation) { passbandCompensation = newCompensation; }
+
+    /** Sets whether the first pole is one octave above (TB-303 style ~18dB/oct slope). */
+    void setOctaveMode(bool enabled) { octaveMode = enabled; }
+
+    //---------------------------------------------------------------------------------------------
+    // inquiry:
+
+    /** Returns the cutoff frequency of this filter. */
+    double getCutoff() const { return cutoff; }
+
+    /** Returns the resonance parameter of this filter (0-1 range, pre-skewed). */
+    double getResonance() const { return resonance; }
+
+    /** Returns the drive parameter in decibels. */
+    double getDrive() const { return drive; }
+
+    /** Returns the passband gain compensation amount (0.0 = none, 1.0 = full compensation). */
+    double getPassbandCompensation() const { return passbandCompensation; }
+
+    //---------------------------------------------------------------------------------------------
+    // audio processing:
+
+    /** Calculates one output sample at a time. */
+    INLINE double getSample(double in);
+
+    //---------------------------------------------------------------------------------------------
+    // others:
+
+    /** Causes the filter to re-calculate the coefficients. */
+    INLINE void calculateCoefficients();
+
+    /** Implements the waveshaping nonlinearity. */
+    INLINE double shape(double x);
+
+    /** Resets the internal state variables. */
+    void reset();
+
+    //=============================================================================================
+
+  protected:
+
+    // State variables for the 4 one-pole filter stages
+    double z1, z2, z3, z4;
+
+    // Coefficients for the diode ladder topology
+    double alpha;           // g / (1 + g) - the one-pole alpha
+    double alpha2;          // one octave above, for 1st stage
+    double G1, G2, G3, G4;  // "Big G" coefficients
+    double beta1, beta2, beta3, beta4;   // feedback beta coefficients
+    double delta1, delta2, delta3;       // delta coefficients
+    double gamma1, gamma2, gamma3;       // gamma coefficients (not to confuse with GAMMA)
+    double epsilon1, epsilon2, epsilon3; // epsilon coefficients
+    double SG1, SG2, SG3, SG4;          // sigma gain coefficients
+    double GAMMA;           // product of all G's
+    double K;               // resonance/feedback factor
+
+    // Scaling factors for each stage (a0 values from Pirkle)
+    static constexpr double a1 = 1.0;
+    static constexpr double a2 = 0.5;
+    static constexpr double a3 = 0.5;
+    static constexpr double a4 = 0.5;
+
+    // Filter parameters
+    double cutoff;
+    double drive;
+    double driveFactor;
+    double passbandCompensation;  // 0.0 = no compensation, 1.0 = full (1+K) boost
+    double resonance;             // resonance parameter (0-1, pre-skewed by Open303)
+    double sampleRate;
+    bool   octaveMode;            // true = 1st pole one octave above (TB-303 style)
+  };
+
+  //-----------------------------------------------------------------------------------------------
+  // inlined functions:
+
+  INLINE void DiodeLadderFilter::setCutoff(double newCutoff, bool updateCoefficients)
+  {
+    if( newCutoff != cutoff )
+    {
+      if( newCutoff < 200.0 )
+        cutoff = 200.0;
+      else if( newCutoff > 20000.0 )
+        cutoff = 20000.0;
+      else
+        cutoff = newCutoff;
+
+      if( updateCoefficients == true )
+        calculateCoefficients();
+    }
+  }
+
+  INLINE void DiodeLadderFilter::setResonance(double newResonance, bool updateCoefficients)
+  {
+    // newResonance is already skewed (0-1 range) from Open303
+    resonance = newResonance;
+
+    if( updateCoefficients == true )
+      calculateCoefficients();
+  }
+
+  INLINE void DiodeLadderFilter::calculateCoefficients()
+  {
+    // Bilinear transform calculations
+    double wd = 2.0 * PI * cutoff;
+    double T = 1.0 / sampleRate;
+    double wa = (2.0 / T) * tan(wd * T / 2.0);
+    double gCoeff = wa * T / 2.0;
+    double gp1 = 1.0 + gCoeff;
+
+    // Calculate "Big G" coefficients (feedback path gains)
+    G4 = 0.5 * gCoeff / gp1;
+    G3 = 0.5 * gCoeff / (gp1 - 0.5 * gCoeff * G4);
+    G2 = 0.5 * gCoeff / (gp1 - 0.5 * gCoeff * G3);
+    G1 = gCoeff / (gp1 - gCoeff * G2);
+
+    // Product of all G's
+    GAMMA = G4 * G3 * G2 * G1;
+
+    // Sigma gain coefficients
+    SG1 = G4 * G3 * G2;
+    SG2 = G4 * G3;
+    SG3 = G4;
+    SG4 = 1.0;
+
+    // One-pole alpha coefficient
+    alpha = gCoeff / gp1;
+
+    // Alpha for 1st stage (one octave above, like TB-303)
+    double wa2 = (2.0 / T) * tan(2*wd * T / 2.0);
+    double g2 = wa2 * T / 2.0;
+    alpha2 = g2 / (1.0 + g2);
+
+    // Beta coefficients
+    beta1 = 1.0 / (gp1 - gCoeff * G2);
+    beta2 = 1.0 / (gp1 - 0.5 * gCoeff * G3);
+    beta3 = 1.0 / (gp1 - 0.5 * gCoeff * G4);
+    beta4 = 1.0 / gp1;
+
+    // Gamma coefficients (local feedback)
+    gamma1 = 1.0 + G1 * G2;
+    gamma2 = 1.0 + G2 * G3;
+    gamma3 = 1.0 + G3 * G4;
+
+    // Delta coefficients
+    delta1 = gCoeff;
+    delta2 = 0.5 * gCoeff;
+    delta3 = 0.5 * gCoeff;
+
+    // Epsilon coefficients
+    epsilon1 = G2;
+    epsilon2 = G3;
+    epsilon3 = G4;
+
+    // K maps resonance 0-1 to approximately 0-17 for self-oscillation
+    // (17 is the theoretical self-oscillation point for diode ladder)
+    K = 17.0 * resonance;
+  }
+
+  INLINE double DiodeLadderFilter::shape(double x)
+  {
+    // Soft clipping - tanh approximation
+    return math_approx::tanh<7>(x);
+  }
+
+  INLINE double DiodeLadderFilter::getSample(double in)
+  {
+    // Input without compensation - compensation applied at output
+    double input = in;
+
+    // Calculate feedback signals (S4 -> S3 -> S2 -> S1)
+    double S4 = beta4 * z4;
+    double S3 = beta3 * (z3 + S4 * delta3);
+    double S2 = beta2 * (z2 + S3 * delta2);
+    double S1 = beta1 * (z1 + S2 * delta1);
+
+    // SIGMA - weighted sum of feedback signals
+    double SIGMA = SG1 * S1 + SG2 * S2 + SG3 * S3 + SG4 * S4;
+
+    // Form input to the ladder (with feedback)
+    double un = (input - K * SIGMA) / (1.0 + K * GAMMA);
+
+    // Apply input nonlinearity
+    un = shape(driveFactor * un);
+
+    // 1st stage (optionally one octave above for TB-303 style slope)
+    double xin = un * gamma1 + S2 + epsilon1 * S1;
+    double v = (a1 * xin - z1) * (octaveMode ? alpha2 : alpha);
+    double lp = v + z1;
+    z1 = lp + v;
+
+    // 2nd stage
+    xin = lp * gamma2 + S3 + epsilon2 * S2;
+    v = (a2 * xin - z2) * alpha;
+    lp = v + z2;
+    z2 = lp + v;
+
+    // 3rd stage
+    xin = lp * gamma3 + S4 + epsilon3 * S3;
+    v = (a3 * xin - z3) * alpha;
+    lp = v + z3;
+    z3 = lp + v;
+
+    // 4th stage
+    v = (a4 * lp - z4) * alpha;
+    lp = v + z4;
+    z4 = lp + v;
+
+    // Oberheim variations
+    // return c.mA * dU + c.mB * dLP1 + c.mC * dLP2 + c.mD * dLP3 +  c.mE * dLP4;
+
+    // Apply passband gain compensation at output (keeps saturation independent of compensation)
+    return lp * (1.0 + passbandCompensation * K);
+  }
+
+} // end namespace dfl
+
+#endif // dfl_DiodeLadderFilter_h

--- a/src/dsp/open303/rosic_Open303.cpp
+++ b/src/dsp/open303/rosic_Open303.cpp
@@ -29,6 +29,7 @@ Open303::Open303()
   noteOffCountDown =     0;
   slideToNextNote  = false;
   idle             = true;
+  currentFilterType = FILTER_TEEBEE;
 
   setEnvMod(25.0);
 
@@ -99,12 +100,33 @@ void Open303::setSampleRate(double newSampleRate)
 
   oscillator.setSampleRate    (  oversampling*newSampleRate);
   filter.setSampleRate        (  oversampling*newSampleRate);
+  diodeFilter.setSampleRate   (  oversampling*newSampleRate);
 }
 
 void Open303::setCutoff(double newCutoff)
 {
   cutoff = newCutoff;
   calculateEnvModScalerAndOffset();
+}
+
+void Open303::setResonance(double newResonance)
+{
+  // Apply skewing for more intuitive control (aggressive at high end)
+  double skewedResonance = newResonance * newResonance * newResonance;
+
+  filter.setResonance(newResonance);
+  diodeFilter.setResonance(skewedResonance);
+}
+
+void Open303::setFilterType(FilterType newType)
+{
+  currentFilterType = newType;
+
+  // Configure diode filter octave mode based on filter type
+  if(currentFilterType == FILTER_DIODE_OCTAVE)
+    diodeFilter.setOctaveMode(true);
+  else
+    diodeFilter.setOctaveMode(false);
 }
 
 void Open303::setEnvMod(double newEnvMod)
@@ -217,6 +239,7 @@ void Open303::triggerNote(int noteNumber, bool hasAccent)
   {
     oscillator.resetPhase();
     filter.reset();
+    diodeFilter.reset();
     highpass1.reset();
     highpass2.reset();
     allpass.reset();

--- a/src/dsp/open303/rosic_Open303.h
+++ b/src/dsp/open303/rosic_Open303.h
@@ -76,7 +76,14 @@ namespace rosic
     /** Returns the current filter type. */
     FilterType getFilterType() const { return currentFilterType; }
 
-    /** Sets the modulation depth of the filter's cutoff frequency by the filter-envelope generator 
+    /** Sets the Filter FM depth (0-1). Devilfish-style audio-rate cutoff modulation.
+     *  Uses AC-coupled input to modulate filter cutoff frequency. */
+    void setFilterFmDepth(double depth) { diodeFilter.setFilterFmDepth(depth); }
+
+    /** Returns the Filter FM depth. */
+    double getFilterFmDepth() const { return diodeFilter.getFilterFmDepth(); }
+
+    /** Sets the modulation depth of the filter's cutoff frequency by the filter-envelope generator
     (in percent). */
     void setEnvMod(double newEnvMod);
 

--- a/src/dsp/open303/rosic_Open303.h
+++ b/src/dsp/open303/rosic_Open303.h
@@ -6,6 +6,7 @@
 #include "rosic_BlendOscillator.h"
 #include "rosic_BiquadFilter.h"
 #include "rosic_TeeBeeFilter.h"
+#include "dfl_DiodeLadderFilter.h"
 #include "rosic_AnalogEnvelope.h"
 #include "rosic_DecayEnvelope.h"
 #include "rosic_LeakyIntegrator.h"
@@ -17,6 +18,17 @@ using namespace std; // for the noteList
 
 namespace rosic
 {
+  // Import dfl classes
+  using dfl::DiodeLadderFilter;
+
+  /** Filter types available for selection. */
+  enum FilterType
+  {
+    FILTER_TEEBEE = 0,      // Original TB-303 transistor ladder
+    FILTER_DIODE,           // Diode ladder (4-pole, 24dB/oct)
+    FILTER_DIODE_OCTAVE,    // Diode ladder with 1st pole one octave above (~18dB/oct)
+    NUM_FILTER_TYPES
+  };
 
   /**
 
@@ -56,7 +68,13 @@ namespace rosic
     void setCutoff(double newCutoff); 
 
     /** Sets the resonance amount for the filter. */
-    void setResonance(double newResonance) { filter.setResonance(newResonance); }
+    void setResonance(double newResonance);
+
+    /** Sets the filter type. */
+    void setFilterType(FilterType newType);
+
+    /** Returns the current filter type. */
+    FilterType getFilterType() const { return currentFilterType; }
 
     /** Sets the modulation depth of the filter's cutoff frequency by the filter-envelope generator 
     (in percent). */
@@ -240,6 +258,7 @@ namespace rosic
     MipMappedWaveTable        waveTable1, waveTable2;
     BlendOscillator           oscillator;
     TeeBeeFilter              filter;
+    DiodeLadderFilter         diodeFilter;
     AnalogEnvelope            ampEnv; 
     DecayEnvelope             mainEnv;
     LeakyIntegrator           pitchSlewLimiter;
@@ -307,6 +326,7 @@ namespace rosic
     int    noteOffCountDown; // a countdown variable till next note-off in sequencer mode
     bool   slideToNextNote;  // indicate that we need to slide to the next note in sequencer mode
     bool   idle;             // flag to indicate that we have currently nothing to do in getSample
+    FilterType currentFilterType;  // currently selected filter type
 
     list<MidiNoteEvent> noteList;
 
@@ -374,6 +394,7 @@ namespace rosic
     tmp2 = accentGain*tmp2;
     double instCutoff = cutoff * pow(2.0, tmp1+tmp2);
     filter.setCutoff(instCutoff);
+    diodeFilter.setCutoff(instCutoff);
 
     double ampEnvOut = ampEnv.getSample();
     //ampEnvOut += 0.45*filterEnvOut + accentGain*6.8*filterEnvOut; 
@@ -385,9 +406,13 @@ namespace rosic
     double tmp;
     for(int i=1; i<=oversampling; i++)
     {
-      tmp  = -oscillator.getSample();         // the raw oscillator signal 
+      tmp  = -oscillator.getSample();         // the raw oscillator signal
       tmp  = highpass1.getSample(tmp);        // pre-filter highpass
-      tmp  = filter.getSample(tmp);           // now it's filtered
+      // Apply selected filter
+      if(currentFilterType == FILTER_TEEBEE)
+        tmp = filter.getSample(tmp);
+      else
+        tmp = diodeFilter.getSample(tmp);
       tmp  = antiAliasFilter.getSample(tmp);  // anti-aliasing filtered
 
     }


### PR DESCRIPTION
## Summary
- AC-coupled input signal modulates filter cutoff at audio rate
- One-pole HPF (~20Hz) removes DC before modulation  
- Creates FM sidebands, talking/screaming character with resonance
- New `setFilterFmDepth()` API (0-100%)

Based on Devilfish mod: "Filter FM uses the output of the VCA, AC coupled into the filter cutoff frequency"

## Dependencies
⚠️ **Depends on PR #33** (diode-ladder-filter) - merge that first

🤖 Generated with [Claude Code](https://claude.com/claude-code)