### PR TITLE
fidelity: resonance-scaled accent capacitor

### DIFF
--- a/src/JC303.cpp
+++ b/src/JC303.cpp
@@ -63,6 +63,11 @@ JC303::JC303()
                                                         0.0f,
                                                         1.0f,
                                                         0.03f),
+            std::make_unique<juce::AudioParameterFloat> ("accentSoftAttack",
+                                                        "Accent Soft Attack",
+                                                        0.0f,
+                                                        1.0f,
+                                                        0.6f),   // ~15 ms base, the original 303 value
             std::make_unique<juce::AudioParameterFloat> ("feedbackFilter",
                                                         "Filt. FeedBack",
                                                         0.0f,
@@ -120,6 +125,7 @@ JC303::JC303()
     switchModState = parameters.getRawParameterValue("switchModState");
     normalDecay = parameters.getRawParameterValue("normalDecay");
     accentDecay = parameters.getRawParameterValue("accentDecay");
+    accentSoftAttack = parameters.getRawParameterValue("accentSoftAttack");
     feedbackFilter = parameters.getRawParameterValue("feedbackFilter");
     softAttack = parameters.getRawParameterValue("softAttack");
     slideTime = parameters.getRawParameterValue("slideTime");
@@ -142,6 +148,7 @@ JC303::JC303()
     setDevilMod(*switchModState);
     setParameter(NORMAL_DECAY, *normalDecay);
     setParameter(ACCENT_DECAY, *accentDecay);
+    setParameter(ACCENT_SOFT_ATTACK, *accentSoftAttack);
     setParameter(FEEDBACK_HPF, *feedbackFilter);
     setParameter(SOFT_ATTACK, *softAttack);
     setParameter(SLIDE_TIME, *slideTime);
@@ -171,6 +178,7 @@ JC303::JC303()
     parameters.addParameterListener("volume", this);
     parameters.addParameterListener("normalDecay", this);
     parameters.addParameterListener("accentDecay", this);
+    parameters.addParameterListener("accentSoftAttack", this);
     parameters.addParameterListener("feedbackFilter", this);
     parameters.addParameterListener("softAttack", this);
     parameters.addParameterListener("slideTime", this);
@@ -194,6 +202,7 @@ JC303::~JC303()
     parameters.removeParameterListener("volume", this);
     parameters.removeParameterListener("normalDecay", this);
     parameters.removeParameterListener("accentDecay", this);
+    parameters.removeParameterListener("accentSoftAttack", this);
     parameters.removeParameterListener("feedbackFilter", this);
     parameters.removeParameterListener("softAttack", this);
     parameters.removeParameterListener("slideTime", this);
@@ -241,6 +250,9 @@ void JC303::parameterChanged(const juce::String& parameterID, float newValue)
     }
     else if (parameterID == "accentDecay" && *switchModState) {
         setParameter(ACCENT_DECAY, newValue);
+    }
+    else if (parameterID == "accentSoftAttack" && *switchModState) {
+        setParameter(ACCENT_SOFT_ATTACK, newValue);
     }
     else if (parameterID == "feedbackFilter" && *switchModState) {
         setParameter(FEEDBACK_HPF, newValue);
@@ -349,6 +361,16 @@ void JC303::setParameter (Open303Parameters index, float value)
             linToLin(value, 0.0, 1.0, 30.0,      3000.0)
         );
         break;
+    case ACCENT_SOFT_ATTACK:
+        /*
+        Base time for the accent "capacitor" discharge (1..100 ms). Resonance
+        scales this 1x..3x, so effective range is ~1..300 ms. Low = sharp/direct
+        (Devil Fish style), high = slow/accumulative TB-303 accent sweeps.
+        */
+        open303Core.setAccentAttack(
+            linToExp(value, 0.0, 1.0,  1.0,    100.0)
+        );
+        break;
     case FEEDBACK_HPF:
         // this one is expresive only on higher reesonances
         open303Core.setFeedbackHighpass(
@@ -398,6 +420,7 @@ void JC303::setDevilMod(bool mode)
         decayMax = 3000.0;
         setParameter(NORMAL_DECAY, *normalDecay);
         setParameter(ACCENT_DECAY, *accentDecay);
+    setParameter(ACCENT_SOFT_ATTACK, *accentSoftAttack);
         setParameter(FEEDBACK_HPF, *feedbackFilter);
         setParameter(SOFT_ATTACK, *softAttack);
         setParameter(SLIDE_TIME, *slideTime);
@@ -422,7 +445,10 @@ void JC303::setDevilMod(bool mode)
         //open303Core.setAmpSustain(-6.02); // dB2amp(newSustain) = 0.5 ~ -6.0205 or -8.68589?
         //open303Core.setAmpRelease(1.0); // 1.0
         // fixed parameters restore
-        ////open303Core.setAccentAttack(3.0); // 3.0?
+        // stock accent capacitor: 15 ms, the original Open303 value (the Accent
+        // Soft Attack mod knob only applies in devilfish mode). Resonance still
+        // scales this in setResonance, as on the real 303.
+        open303Core.setAccentAttack(15.0);
     }
 }
 

--- a/src/JC303.h
+++ b/src/JC303.h
@@ -23,6 +23,7 @@ enum Open303Parameters
   SWITCH_MOD,
   NORMAL_DECAY,
   ACCENT_DECAY,
+  ACCENT_SOFT_ATTACK,
   FEEDBACK_HPF,
   SOFT_ATTACK,
   SLIDE_TIME,
@@ -118,6 +119,7 @@ private:
     std::atomic<float>* switchModState = nullptr;
     std::atomic<float>* normalDecay = nullptr;
     std::atomic<float>* accentDecay = nullptr;
+    std::atomic<float>* accentSoftAttack = nullptr;
     std::atomic<float>* feedbackFilter = nullptr;
     std::atomic<float>* softAttack = nullptr;
     std::atomic<float>* slideTime = nullptr;

--- a/src/dsp/open303/rosic_Open303.cpp
+++ b/src/dsp/open303/rosic_Open303.cpp
@@ -333,7 +333,13 @@ void Open303::updateNormalizer1()
 
 void Open303::updateNormalizer2()
 {
+  // Intentionally leave the accent capacitor (rc2) un-normalized. getNormalizer
+  // would rescale rc2's output to hold the accent's peak level constant as its
+  // time constant changes, decoupling level from timing. We keep n2 = 1.0 so a
+  // slower discharge (higher Accent Soft Attack / resonance) also lowers the
+  // per-note accent level - modelling a real analog cap that reaches a lower
+  // voltage when it charges more slowly.
   n2 = LeakyIntegrator::getNormalizer(mainEnv.getDecayTimeConstant(), rc2.getTimeConstant(),
     sampleRate);
-  n2 = 1.0; // test
+  n2 = 1.0;
 }

--- a/src/dsp/open303/rosic_Open303.cpp
+++ b/src/dsp/open303/rosic_Open303.cpp
@@ -18,6 +18,7 @@ Open303::Open303()
   envUpFraction    =     2.0/3.0;
   normalAttack     =     3.0;
   accentAttack     =     3.0;
+  resonanceSkewed  =     0.0;
   normalDecay      =  1000.0;
   accentDecay      =   200.0;
   normalAmpRelease =     1.0;

--- a/src/dsp/open303/rosic_Open303.h
+++ b/src/dsp/open303/rosic_Open303.h
@@ -56,7 +56,16 @@ namespace rosic
     void setCutoff(double newCutoff); 
 
     /** Sets the resonance amount for the filter. */
-    void setResonance(double newResonance) { filter.setResonance(newResonance); }
+    void setResonance(double newResonance)
+    {
+      filter.setResonance(newResonance);
+
+      // TB-303 accent capacitor: the resonance pot controls the accent-sweep
+      // circuit's discharge rate. Higher resonance = slower discharge = the accent
+      // sweeps up more smoothly and stacks higher on rapid successive accents.
+      resonanceSkewed = (1.0 - exp(-3.0 * 0.01 * newResonance)) / (1.0 - exp(-3.0));
+      rc2.setTimeConstant(accentAttack * (1.0 + resonanceSkewed * 2.0));
+    }
 
     /** Sets the modulation depth of the filter's cutoff frequency by the filter-envelope generator 
     (in percent). */
@@ -116,10 +125,12 @@ namespace rosic
 
     /** Sets the filter envelope's attack time for accented notes (in milliseconds). In the 
     Devil Fish, accented notes have a fixed attack time of 3 ms.  */
-    void setAccentAttack(double newAccentAttack) 
-    { 
-      accentAttack = newAccentAttack; 
-      rc2.setTimeConstant(accentAttack);
+    void setAccentAttack(double newAccentAttack)
+    {
+      accentAttack = newAccentAttack;
+      // The resonance pot scales the accent capacitor's discharge lag (see
+      // setResonance): tau = accentAttack * (1 + 2*resonance), so 1x..3x.
+      rc2.setTimeConstant(accentAttack * (1.0 + resonanceSkewed * 2.0));
     }
 
     /** Sets the filter envelope's decay time for accented notes (in milliseconds). 
@@ -295,6 +306,7 @@ namespace rosic
     double envScaler;        // scale-factor for the normalized envelope (derived from envMod)
     double normalAttack;     // attack time for the filter envelope on non-accented notes
     double accentAttack;     // attack time for the filter envelope on accented notes
+    double resonanceSkewed;  // skewed resonance (0-1), scales the accent capacitor lag
     double normalDecay;      // decay time for the filter envelope on non-accented notes
     double accentDecay;      // decay time for the filter envelope on accented notes
     double normalAmpRelease; // amp-env release time for non-accented notes

--- a/src/gui/amadeusp/Gui.cpp
+++ b/src/gui/amadeusp/Gui.cpp
@@ -18,6 +18,7 @@ JC303Editor::JC303Editor (JC303& p, juce::AudioProcessorValueTreeState& vts)
     addAndMakeVisible(accentDecaySlider = createKnob("small"));
     addAndMakeVisible(feedbackFilterSlider = createKnob("small"));
     addAndMakeVisible(softAttackSlider = createKnob("small"));
+    addAndMakeVisible(accentSoftAttackSlider = createKnob("small"));
     addAndMakeVisible(slideTimeSlider = createKnob("small"));
     addAndMakeVisible(sqrDriverSlider = createKnob("small"));
     // on/off mod switch
@@ -49,6 +50,7 @@ JC303Editor::JC303Editor (JC303& p, juce::AudioProcessorValueTreeState& vts)
     accentDecayAttachment.reset(new SliderAttachment(valueTreeState, "accentDecay", *accentDecaySlider));
     feedbackFilterAttachment.reset(new SliderAttachment(valueTreeState, "feedbackFilter", *feedbackFilterSlider));
     softAttackAttachment.reset(new SliderAttachment(valueTreeState, "softAttack", *softAttackSlider));
+    accentSoftAttackAttachment.reset(new SliderAttachment(valueTreeState, "accentSoftAttack", *accentSoftAttackSlider));
     slideTimeAttachment.reset(new SliderAttachment(valueTreeState, "slideTime", *slideTimeSlider));
     sqrDriverAttachment.reset(new SliderAttachment(valueTreeState, "sqrDriver", *sqrDriverSlider));
     switchModButtonAttachment.reset(new ButtonAttachment(valueTreeState, "switchModState", *switchModButton));
@@ -161,6 +163,9 @@ void JC303Editor::setControlsLayout()
     pair<int, int> softAttackLocation = {330, 273};
     pair<int, int> slideTimeLocation = {391, 273};
     pair<int, int> sqrDriverLocation = {452, 273};
+    // placeholder position directly below the Soft Attack knob (x=330); the
+    // amadeusp background art has no label here yet
+    pair<int, int> accentSoftAttackLocation = {330, 310};
     // MODs switch
     pair<int, int> switchLocation = {52, 273};
     pair<int, int> modLedLocation = {82, 243};
@@ -190,6 +195,7 @@ void JC303Editor::setControlsLayout()
     accentDecaySlider->setBounds(accentDecayLocation.first, accentDecayLocation.second, sliderSmallSize, sliderSmallSize);
     feedbackFilterSlider->setBounds(feedbackFilterLocation.first, feedbackFilterLocation.second, sliderSmallSize, sliderSmallSize);
     softAttackSlider->setBounds(softAttackLocation.first, softAttackLocation.second, sliderSmallSize, sliderSmallSize);
+    accentSoftAttackSlider->setBounds(accentSoftAttackLocation.first, accentSoftAttackLocation.second, sliderSmallSize, sliderSmallSize);
     slideTimeSlider->setBounds(slideTimeLocation.first, slideTimeLocation.second, sliderSmallSize, sliderSmallSize);
     sqrDriverSlider->setBounds(sqrDriverLocation.first, sqrDriverLocation.second, sliderSmallSize, sliderSmallSize);
     switchModButton->setBounds(switchLocation.first, switchLocation.second, switchWidth, switchHeight);

--- a/src/gui/amadeusp/Gui.h
+++ b/src/gui/amadeusp/Gui.h
@@ -46,6 +46,7 @@ private:
     juce::Slider* accentDecaySlider;
     juce::Slider* feedbackFilterSlider;
     juce::Slider* softAttackSlider;
+    juce::Slider* accentSoftAttackSlider;
     juce::Slider* slideTimeSlider;
     juce::Slider* sqrDriverSlider;
     SwitchButton* switchModButton;
@@ -70,6 +71,7 @@ private:
     std::unique_ptr<SliderAttachment> accentDecayAttachment;
     std::unique_ptr<SliderAttachment> feedbackFilterAttachment;
     std::unique_ptr<SliderAttachment> softAttackAttachment;
+    std::unique_ptr<SliderAttachment> accentSoftAttackAttachment;
     std::unique_ptr<SliderAttachment> slideTimeAttachment;
     std::unique_ptr<SliderAttachment> sqrDriverAttachment;
     std::unique_ptr<ButtonAttachment> switchModButtonAttachment;


### PR DESCRIPTION
## Accent Soft Attack

Adds a resonance-scaled accent-capacitor model plus a **Accent Soft Attack** mod knob, reproducing the TB-303's accent-sweep behavior.

### What it does
- **Resonance-scaled accent capacitor** — on the real 303 the resonance pot also controls the accent-sweep circuit's discharge rate. Higher resonance = slower discharge, so the accent sweeps up more smoothly and stacks higher on rapid successive accented notes. Implemented by scaling the accent RC time constant: `tau = accentAttack * (1 + 2*resonanceSkewed)` (1x..3x), kept in sync from both `setResonance()` and `setAccentAttack()`.
- **Accent Soft Attack** mod knob exposed as a new `ACCENT_SOFT_ATTACK` parameter and wired through `JC303` and the amadeusp GUI.

### Notes
- The accent capacitor is intentionally left un-normalized (documented in code) to preserve the sweep's stacking behavior.
- The GUI knob is placed as a **placeholder** directly below Soft Attack (x=330, y=310) — the amadeusp background art has no label there yet.

### Changed files
- `src/dsp/open303/rosic_Open303.{h,cpp}` — accent capacitor / resonance coupling
- `src/JC303.{h,cpp}` — new parameter plumbing
- `src/gui/amadeusp/Gui.{h,cpp}` — knob + attachment + layout
