### PR TITLE
feat: BP/HP filter modes (stacked on #33 diode filters)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources("${PROJECT_NAME}"
         dsp/open303/rosic_Open303.cpp
         dsp/open303/rosic_RealFunctions.cpp
         dsp/open303/rosic_TeeBeeFilter.cpp
+        dsp/open303/dfl_DiodeLadderFilter.cpp
         dsp/open303/dfl_LFO.cpp
 
         gui/${GUI_THEME}/Gui.cpp

--- a/src/JC303.cpp
+++ b/src/JC303.cpp
@@ -129,7 +129,7 @@ JC303::JC303()
             // filter model selection
             std::make_unique<juce::AudioParameterChoice> ("filterType",
                                                         "Filter Model",
-                                                        juce::StringArray{ "TeeBee", "Diode Octave", "Diode" },
+                                                        juce::StringArray{ "TeeBee", "Diode Octave", "Diode", "Diode BP", "Diode HP" },
                                                         FILTER_TEEBEE),
             std::make_unique<juce::AudioParameterFloat> ("filterDrive",
                                                         "Filter Drive",

--- a/src/JC303.cpp
+++ b/src/JC303.cpp
@@ -125,7 +125,22 @@ JC303::JC303()
                                                         0.25f),
             std::make_unique<juce::AudioParameterBool> ("switchOverdriveState",
                                                         "Switch Overdrive Mod",
-                                                        false)
+                                                        false),
+            // filter model selection
+            std::make_unique<juce::AudioParameterChoice> ("filterType",
+                                                        "Filter Model",
+                                                        juce::StringArray{ "TeeBee", "Diode Octave", "Diode" },
+                                                        FILTER_TEEBEE),
+            std::make_unique<juce::AudioParameterFloat> ("filterDrive",
+                                                        "Filter Drive",
+                                                        0.0f,
+                                                        1.0f,
+                                                        0.5f),   // ~4.5 dB into the diode saturator by default
+            std::make_unique<juce::AudioParameterFloat> ("bassComp",
+                                                        "Bass Comp",
+                                                        0.0f,
+                                                        1.0f,
+                                                        0.1f)   // light passband/bass makeup by default
        })
 {
     // assign a pointer to use it around for each parameter
@@ -155,6 +170,10 @@ JC303::JC303()
     switchOverdriveState = parameters.getRawParameterValue("switchOverdriveState");
     overdriveLevel = parameters.getRawParameterValue("overdriveLevel");
     overdriveDryWet = parameters.getRawParameterValue("overdriveDryWet");
+    // filter model
+    filterType = parameters.getRawParameterValue("filterType");
+    filterDrive = parameters.getRawParameterValue("filterDrive");
+    bassComp = parameters.getRawParameterValue("bassComp");
 
     // force initial user values(some hosts migth not do it using value tree state)
     setParameter(WAVEFORM, *waveForm);
@@ -181,6 +200,9 @@ JC303::JC303()
     setParameter(OVERDRIVE_LEVEL, *overdriveLevel);
     setParameter(OVERDRIVE_DRY_WET, *overdriveDryWet);
     setParameter(OVERDRIVE_MODEL_INDEX, *overdriveModelIndex);
+    open303Core.setFilterType(static_cast<FilterType>((int) *filterType));
+    setParameter(FILTER_DRIVE, *filterDrive);
+    setParameter(BASS_COMP, *bassComp);
 
     // presets and overdrive models
     setupDataDirectories();
@@ -218,6 +240,9 @@ JC303::JC303()
     parameters.addParameterListener("overdriveDryWet", this);
     parameters.addParameterListener("overdriveModelIndex", this);
     parameters.addParameterListener("switchOverdriveState", this);
+    parameters.addParameterListener("filterType", this);
+    parameters.addParameterListener("filterDrive", this);
+    parameters.addParameterListener("bassComp", this);
 }
 
 JC303::~JC303()
@@ -247,6 +272,9 @@ JC303::~JC303()
     parameters.removeParameterListener("overdriveDryWet", this);
     parameters.removeParameterListener("overdriveModelIndex", this);
     parameters.removeParameterListener("switchOverdriveState", this);
+    parameters.removeParameterListener("filterType", this);
+    parameters.removeParameterListener("filterDrive", this);
+    parameters.removeParameterListener("bassComp", this);
 }
 
 // Parameter change callback
@@ -320,6 +348,15 @@ void JC303::parameterChanged(const juce::String& parameterID, float newValue)
     }
     else if (parameterID == "overdriveModelIndex") {
         setParameter(OVERDRIVE_MODEL_INDEX, newValue);
+    }
+    else if (parameterID == "filterType") {
+        open303Core.setFilterType(static_cast<FilterType>((int) newValue));
+    }
+    else if (parameterID == "filterDrive") {
+        setParameter(FILTER_DRIVE, newValue);
+    }
+    else if (parameterID == "bassComp") {
+        setParameter(BASS_COMP, newValue);
     }
 }
 
@@ -440,6 +477,18 @@ void JC303::setParameter (Open303Parameters index, float value)
             linToLin(value, 0.0, 1.0,   25.0,     80.0)
             //linToLin(value, 0.0, 1.0,   36.9,     90.0)
         );
+        break;
+    case FILTER_DRIVE:
+        // 0..1 -> 0..9 dB into the diode ladder's saturating input stage
+        // (matches the DB303 plugin's tuned range; the unity-makeup shaper
+        // here has no headroom scaling, so it already runs hot per-dB)
+        open303Core.setFilterDrive(
+            linToLin(value, 0.0, 1.0,   0.0,     9.0)
+        );
+        break;
+    case BASS_COMP:
+        // 0..1 diode-ladder passband (bass) compensation, applied directly
+        open303Core.setPassbandCompensation(value);
         break;
 
     // LFO parameters

--- a/src/JC303.h
+++ b/src/JC303.h
@@ -27,6 +27,8 @@ enum Open303Parameters
   SOFT_ATTACK,
   SLIDE_TIME,
   TANH_SHAPER_DRIVE,
+  FILTER_DRIVE,
+  BASS_COMP,
   // LFO
   LFO_WAVEFORM,
   LFO_RATE,
@@ -137,6 +139,9 @@ private:
     std::atomic<float>* switchOverdriveState = nullptr;
     std::atomic<float>* overdriveLevel = nullptr;
     std::atomic<float>* overdriveDryWet = nullptr;
+    std::atomic<float>* filterType = nullptr;
+    std::atomic<float>* filterDrive = nullptr;
+    std::atomic<float>* bassComp = nullptr;
 
     double decayMin = 200;
     double decayMax = 2000;

--- a/src/dsp/open303/dfl_DiodeLadderFilter.cpp
+++ b/src/dsp/open303/dfl_DiodeLadderFilter.cpp
@@ -14,6 +14,7 @@ DiodeLadderFilter::DiodeLadderFilter()
   resonance           =     0.0;
   sampleRate          = 44100.0;
   octaveMode          =    true;  // default to TB-303 style
+  responseMode        = RESPONSE_LP;
   K                   =     0.0;
 
   // Initialize coefficients

--- a/src/dsp/open303/dfl_DiodeLadderFilter.cpp
+++ b/src/dsp/open303/dfl_DiodeLadderFilter.cpp
@@ -1,0 +1,70 @@
+#include "dfl_DiodeLadderFilter.h"
+using namespace dfl;
+
+//-------------------------------------------------------------------------------------------------
+// construction/destruction:
+
+DiodeLadderFilter::DiodeLadderFilter()
+{
+  cutoff              =  1000.0;
+  driveFactor         =     1.0;
+  driveMakeup         =     1.0;
+  drive               =     0.0;
+  passbandCompensation =    0.0;
+  resonance           =     0.0;
+  sampleRate          = 44100.0;
+  octaveMode          =    true;  // default to TB-303 style
+  K                   =     0.0;
+
+  // Initialize coefficients
+  alpha = 0.0;
+  alpha2 = 0.0;
+  G1 = G2 = G3 = G4 = 0.0;
+  beta1 = beta2 = beta3 = beta4 = 0.0;
+  delta1 = delta2 = delta3 = 0.0;
+  gamma1 = gamma2 = gamma3 = 0.0;
+  epsilon1 = epsilon2 = epsilon3 = 0.0;
+  SG1 = SG2 = SG3 = SG4 = 0.0;
+  GAMMA = 0.0;
+
+  calculateCoefficients();
+  reset();
+}
+
+DiodeLadderFilter::~DiodeLadderFilter()
+{
+}
+
+//-------------------------------------------------------------------------------------------------
+// parameter settings:
+
+void DiodeLadderFilter::setSampleRate(double newSampleRate)
+{
+  if( newSampleRate > 0.0 )
+    sampleRate = newSampleRate;
+  calculateCoefficients();
+}
+
+void DiodeLadderFilter::setInputDrive(double newDrive)
+{
+  drive = newDrive;
+  driveFactor = dB2amp(newDrive);
+  // Small-signal makeup so the drive knob is (roughly) level-neutral instead of
+  // doubling as a volume boost. Full 1/driveFactor makeup over-corrects at real
+  // signal levels (the oscillator hits the filter near unity, deep in the tanh's
+  // compressing region), turning drive into a level cut. A partial exponent is
+  // the best static compromise across resonance settings - see DRIVE_MAKEUP_EXP.
+  driveMakeup = 1.0 / pow(driveFactor, DRIVE_MAKEUP_EXP);
+  calculateCoefficients();  // octave resonance ceiling is scaled by driveMakeup
+}
+
+//-------------------------------------------------------------------------------------------------
+// others:
+
+void DiodeLadderFilter::reset()
+{
+  z1 = 0.0;
+  z2 = 0.0;
+  z3 = 0.0;
+  z4 = 0.0;
+}

--- a/src/dsp/open303/dfl_DiodeLadderFilter.h
+++ b/src/dsp/open303/dfl_DiodeLadderFilter.h
@@ -30,6 +30,16 @@ namespace dfl
 
   public:
 
+    /** Filter response mode. The ladder's per-stage lowpass taps are mixed
+        (Oberheim style) to synthesise band- and high-pass responses from the
+        same 4-pole core - identical coefficients to rosic::TeeBeeFilter. */
+    enum ResponseMode
+    {
+      RESPONSE_LP = 0,  // 4-pole lowpass (24 dB/oct) - the plain diode output
+      RESPONSE_BP,      // bandpass (12/12 dB/oct)
+      RESPONSE_HP       // 4-pole highpass (24 dB/oct)
+    };
+
     //---------------------------------------------------------------------------------------------
     // construction/destruction:
 
@@ -67,6 +77,10 @@ namespace dfl
       }
     }
 
+    /** Sets the response mode (LP/BP/HP). This only re-mixes the ladder's stage
+        outputs, so it needs no coefficient recalculation. @see ResponseMode */
+    INLINE void setResponseMode(int newMode) { responseMode = newMode; }
+
     //---------------------------------------------------------------------------------------------
     // inquiry:
 
@@ -81,6 +95,9 @@ namespace dfl
 
     /** Returns the passband gain compensation amount (0.0 = none, 1.0 = full compensation). */
     double getPassbandCompensation() const { return passbandCompensation; }
+
+    /** Returns the current response mode (LP/BP/HP). @see ResponseMode */
+    int getResponseMode() const { return responseMode; }
 
     //---------------------------------------------------------------------------------------------
     // audio processing:
@@ -171,6 +188,15 @@ namespace dfl
     static constexpr double CUTOFF_TUNING        = 1.41;  // 4-pole (~1/0.71)
     static constexpr double CUTOFF_TUNING_OCTAVE = 1.33;  // octave (peak aligned to TeeBee)
 
+    // Highpass DC-null factor (see RESPONSE_HP in getSample). The textbook binomial
+    // highpass mix un-4lp1+6lp2-4lp3+lp4 assumes each tap is a unity-gain cascade
+    // power (lp_i = un*G^i); this Pirkle diode ladder's a2..a4 = 0.5 stage scaling
+    // breaks that, so the low end fails to cancel and leaks a large (~+11 dB) boost.
+    // Scaling the lowpass-reconstruction term by this factor nulls the DC exactly.
+    // Measured to be 1/5 and independent of cutoff AND resonance (it is fixed by the
+    // a-coefficients), so it is a constant, not a runtime-derived value.
+    static constexpr double HP_LP_SUBTRACT = 0.2;  // = 1/5, DC-null for the HP mix
+
     // Filter parameters
     double cutoff;
     double drive;
@@ -180,6 +206,7 @@ namespace dfl
     double resonance;             // resonance parameter (0-1, pre-skewed by Open303)
     double sampleRate;
     bool   octaveMode;            // true = 1st pole one octave above (TB-303 style)
+    int    responseMode;          // LP/BP/HP output mixing (@see ResponseMode)
   };
 
   //-----------------------------------------------------------------------------------------------
@@ -346,31 +373,67 @@ namespace dfl
     // 1st stage (optionally one octave above for TB-303 style slope)
     double xin = un * gamma1 + S2 + epsilon1 * S1;
     double v = (a1 * xin - z1) * (octaveMode ? alpha2 : alpha);
-    double lp = v + z1;
-    z1 = lp + v;
+    double lp1 = v + z1;
+    z1 = lp1 + v;
 
     // 2nd stage
-    xin = lp * gamma2 + S3 + epsilon2 * S2;
+    xin = lp1 * gamma2 + S3 + epsilon2 * S2;
     v = (a2 * xin - z2) * alpha;
-    lp = v + z2;
-    z2 = lp + v;
+    double lp2 = v + z2;
+    z2 = lp2 + v;
 
     // 3rd stage
-    xin = lp * gamma3 + S4 + epsilon3 * S3;
+    xin = lp2 * gamma3 + S4 + epsilon3 * S3;
     v = (a3 * xin - z3) * alpha;
-    lp = v + z3;
-    z3 = lp + v;
+    double lp3 = v + z3;
+    z3 = lp3 + v;
 
     // 4th stage
-    v = (a4 * lp - z4) * alpha;
-    lp = v + z4;
-    z4 = lp + v;
+    v = (a4 * lp3 - z4) * alpha;
+    double lp4 = v + z4;
+    z4 = lp4 + v;
 
-    // Oberheim variations
-    // return c.mA * dU + c.mB * dLP1 + c.mC * dLP2 + c.mD * dLP3 +  c.mE * dLP4;
+    // Oberheim multi-mode output: mix the ladder's per-stage lowpass taps to
+    // synthesise band- and high-pass responses from the same 4-pole core.
+    //   LP (24 dB/oct):  lp4
+    //   BP (12/12):      lp2 - 2*lp3 + lp4      (0.25 scale)
+    //   HP (24 dB/oct):  un - 0.2*(4*lp1 - 6*lp2 + 4*lp3 - lp4)
+    // where `un` is the (shaped) signal entering the ladder - the y0 term. The HP
+    // uses the DC-null factor HP_LP_SUBTRACT (see there): the plain binomial mix
+    // leaks the low end in this diode topology, so the lowpass-reconstruction term
+    // is scaled to cancel DC, giving a real highpass whose passband gain matches LP
+    // (measured within ~2%). Works in plain and octave mode; the steeper octave 1st
+    // pole just shifts the corner, as it does for LP.
+    double out;
+    switch (responseMode)
+    {
+      case RESPONSE_BP:
+        out = 0.25 * (lp2 - 2.0 * lp3 + lp4);
+        break;
+      case RESPONSE_HP:
+      {
+        // HP mode repurposes the (bass-comp-inert) passbandCompensation knob as a
+        // HP->LP morph: 0 = pure highpass, 1 = pure lowpass, crossfading linearly.
+        // The midpoint is a notch (highs from HP + lows from LP). Both endpoints
+        // share ~the same passband gain, so the sweep stays even in level.
+        double hp = un - HP_LP_SUBTRACT * (4.0 * lp1 - 6.0 * lp2 + 4.0 * lp3 - lp4);
+        double t  = std::clamp(passbandCompensation, 0.0, 1.0);
+        out = (1.0 - t) * hp + t * lp4;
+        break;
+      }
+      case RESPONSE_LP:
+      default:
+        out = lp4;
+        break;
+    }
 
-    // Apply passband gain compensation at output (keeps saturation independent of compensation)
-    return lp * (1.0 + passbandCompensation * K);
+    // Apply passband (bass) gain compensation at output (keeps saturation
+    // independent of it). This restores the LP bass droop that resonance causes.
+    // In HP mode the same knob is repurposed as the HP->LP morph (above), so the
+    // bass-comp boost is not applied there (would double-use the control + run hot).
+    double comp = (responseMode == RESPONSE_HP) ? 1.0
+                                                : (1.0 + passbandCompensation * K);
+    return out * comp;
   }
 
 } // end namespace dfl

--- a/src/dsp/open303/dfl_DiodeLadderFilter.h
+++ b/src/dsp/open303/dfl_DiodeLadderFilter.h
@@ -1,0 +1,378 @@
+#ifndef dfl_DiodeLadderFilter_h
+#define dfl_DiodeLadderFilter_h
+
+// standard-library includes:
+#include <stdlib.h>
+#include <cmath>
+#include <algorithm>   // math_approx.hpp uses std::max/std::min unqualified
+#include <utility>     // math_approx.hpp uses std::make_pair
+
+// rosic includes:
+#include "rosic_RealFunctions.h"
+
+// chowdsp includes:
+#include <math_approx/math_approx.hpp>
+
+namespace dfl
+{
+
+  /**
+   * 4-pole diode ladder filter based on Will Pirkle's analysis.
+   * http://www.willpirkle.com/Downloads/AN-6DiodeLadderFilter.pdf
+   *
+   * This is an alternative to TeeBeeFilter with a different character.
+   * The diode ladder has asymmetric clipping characteristics and a
+   * different resonance behavior compared to the transistor ladder.
+   */
+
+  class DiodeLadderFilter
+  {
+
+  public:
+
+    //---------------------------------------------------------------------------------------------
+    // construction/destruction:
+
+    /** Constructor. */
+    DiodeLadderFilter();
+
+    /** Destructor. */
+    ~DiodeLadderFilter();
+
+    //---------------------------------------------------------------------------------------------
+    // parameter settings:
+
+    /** Sets the sample-rate for this filter. */
+    void setSampleRate(double newSampleRate);
+
+    /** Sets the cutoff frequency for this filter. */
+    INLINE void setCutoff(double newCutoff, bool updateCoefficients = true);
+
+    /** Sets the resonance (0-1 range, pre-skewed by Open303). */
+    INLINE void setResonance(double newResonance, bool updateCoefficients = true);
+
+    /** Sets the input drive in decibels. */
+    void setInputDrive(double newDrive);
+
+    /** Sets the passband gain compensation amount (0.0 = none, 1.0 = full compensation). */
+    void setPassbandCompensation(double newCompensation) { passbandCompensation = newCompensation; }
+
+    /** Sets whether the first pole is one octave above (TB-303 style ~18dB/oct slope). */
+    INLINE void setOctaveMode(bool enabled)
+    {
+      if (enabled != octaveMode)
+      {
+        octaveMode = enabled;
+        calculateCoefficients();  // octave mode caps the resonance (see K below)
+      }
+    }
+
+    //---------------------------------------------------------------------------------------------
+    // inquiry:
+
+    /** Returns the cutoff frequency of this filter. */
+    double getCutoff() const { return cutoff; }
+
+    /** Returns the resonance parameter of this filter (0-1 range, pre-skewed). */
+    double getResonance() const { return resonance; }
+
+    /** Returns the drive parameter in decibels. */
+    double getDrive() const { return drive; }
+
+    /** Returns the passband gain compensation amount (0.0 = none, 1.0 = full compensation). */
+    double getPassbandCompensation() const { return passbandCompensation; }
+
+    //---------------------------------------------------------------------------------------------
+    // audio processing:
+
+    /** Calculates one output sample at a time. */
+    INLINE double getSample(double in);
+
+    //---------------------------------------------------------------------------------------------
+    // others:
+
+    /** Causes the filter to re-calculate the coefficients. */
+    INLINE void calculateCoefficients();
+
+    /** Implements the waveshaping nonlinearity. */
+    INLINE double shape(double x);
+
+    /** Resets the internal state variables. */
+    void reset();
+
+    //=============================================================================================
+
+  protected:
+
+    // State variables for the 4 one-pole filter stages
+    double z1, z2, z3, z4;
+
+    // Coefficients for the diode ladder topology
+    double alpha;           // g / (1 + g) - the one-pole alpha
+    double alpha2;          // one octave above, for 1st stage
+    double G1, G2, G3, G4;  // "Big G" coefficients
+    double beta1, beta2, beta3, beta4;   // feedback beta coefficients
+    double delta1, delta2, delta3;       // delta coefficients
+    double gamma1, gamma2, gamma3;       // gamma coefficients (not to confuse with GAMMA)
+    double epsilon1, epsilon2, epsilon3; // epsilon coefficients
+    double SG1, SG2, SG3, SG4;          // sigma gain coefficients
+    double GAMMA;           // product of all G's
+    double K;               // resonance/feedback factor
+
+    // Scaling factors for each stage (a0 values from Pirkle)
+    static constexpr double a1 = 1.0;
+    static constexpr double a2 = 0.5;
+    static constexpr double a3 = 0.5;
+    static constexpr double a4 = 0.5;
+
+    // Headroom for the input drive stage: scale down before the tanh and back
+    // up after, so 0 dB drive stays clean and the curve is reserved for when
+    // the signal is actually driven. 0.5 = 6 dB headroom (matches DB303).
+    static constexpr double headroomBias = 0.5;
+
+    // Exponent for the drive level-makeup (applied as 1/driveFactor^exp). 0 = no
+    // makeup (drive boosts level), 1 = full makeup (drive cuts level at real
+    // levels). 0.5 keeps the level within ~+-2-3 dB across drive and resonance.
+    static constexpr double DRIVE_MAKEUP_EXP = 0.5;
+
+    // Octave-mode feedback scale (fraction of the plain-diode self-oscillation
+    // point K = 17), calibrated at 1 kHz. 0.85 matches the TeeBee's resonant Q
+    // there across the whole knob range. Plain Diode ignores this and reaches K = 17.
+    static constexpr double OCTAVE_RESONANCE_CEILING = 0.85;
+
+    // Resonance tracking (octave only). The TeeBee's resonant bandwidth is ~constant,
+    // so its Q rises with cutoff; scale the octave feedback by (cutoff/1kHz)^exp to
+    // track it. The knee + tracking are applied to the effective resonance (before
+    // driveMakeup); drive coupling (see OCTAVE_RES_DRIVE_*) is applied here too.
+    // At high cutoff the effective resonance would exceed the octave's self-
+    // oscillation onset (~17.8), so a soft knee saturates it smoothly toward K_CEIL:
+    // transparent below K_KNEE (full resonance through the musical range), asymptoting
+    // to K_CEIL up top so the chirp bites like the TeeBee without self-oscillating.
+    static constexpr double OCTAVE_RES_TRACK_EXP = 0.22;
+    static constexpr double OCTAVE_RES_TRACK_REF = 1000.0;  // Hz where scaling = 1
+    static constexpr double OCTAVE_K_KNEE        = 14.3;    // soft-knee onset (effective)
+    static constexpr double OCTAVE_K_CEIL        = 17.5;    // asymptote, < 17.8 self-osc
+
+    // Drive->resonance coupling (octave only). By default resonance is fully drive-
+    // invariant; above the filterDrive=0.5 calibration point we let harder drive push
+    // the effective resonance further up the soft-knee toward self-oscillation. The
+    // boost is FLOORED at 1.0 at/below the reference, so lowering drive below 0.5 never
+    // weakens resonance - it only cleans up the saturation stage (which still tracks
+    // driveFactor), leaving the lower half of the knob as a pure timbre sweep.
+    // REF is the linear driveFactor at knob 0.5: dB2amp(4.5), where filterDrive 0..1
+    // maps to 0..9 dB (see FILTER_DRIVE in JC303.cpp). EXP sets the coupling strength.
+    static constexpr double OCTAVE_RES_DRIVE_REF = 1.6788;  // = dB2amp(4.5)
+    static constexpr double OCTAVE_RES_DRIVE_EXP = 0.5;     // 0 = no coupling (invariant)
+
+    // Cutoff tuning: the diode ladder's resonant frequency sits below the nominal
+    // cutoff (~0.71x 4-pole, ~0.79x octave), so scale the cutoff up before
+    // computing coefficients to land the resonant peak on the nominal frequency
+    // (matching the TeeBee, whose peak tracks its cutoff 1:1).
+    static constexpr double CUTOFF_TUNING        = 1.41;  // 4-pole (~1/0.71)
+    static constexpr double CUTOFF_TUNING_OCTAVE = 1.33;  // octave (peak aligned to TeeBee)
+
+    // Filter parameters
+    double cutoff;
+    double drive;
+    double driveFactor;
+    double driveMakeup;           // precomputed 1/driveFactor^DRIVE_MAKEUP_EXP
+    double passbandCompensation;  // 0.0 = no compensation, 1.0 = full (1+K) boost
+    double resonance;             // resonance parameter (0-1, pre-skewed by Open303)
+    double sampleRate;
+    bool   octaveMode;            // true = 1st pole one octave above (TB-303 style)
+  };
+
+  //-----------------------------------------------------------------------------------------------
+  // inlined functions:
+
+  INLINE void DiodeLadderFilter::setCutoff(double newCutoff, bool updateCoefficients)
+  {
+    if( newCutoff != cutoff )
+    {
+      if( newCutoff < 200.0 )
+        cutoff = 200.0;
+      else if( newCutoff > 20000.0 )
+        cutoff = 20000.0;
+      else
+        cutoff = newCutoff;
+
+      if( updateCoefficients == true )
+        calculateCoefficients();
+    }
+  }
+
+  INLINE void DiodeLadderFilter::setResonance(double newResonance, bool updateCoefficients)
+  {
+    // newResonance is already skewed (0-1 range) from Open303
+    resonance = newResonance;
+
+    if( updateCoefficients == true )
+      calculateCoefficients();
+  }
+
+  INLINE void DiodeLadderFilter::calculateCoefficients()
+  {
+    // Bilinear transform calculations (cutoff tuned so the resonant peak lands
+    // on the nominal frequency - see CUTOFF_TUNING constants)
+    double tunedCutoff = cutoff * (octaveMode ? CUTOFF_TUNING_OCTAVE : CUTOFF_TUNING);
+    double wd = 2.0 * PI * tunedCutoff;
+    double T = 1.0 / sampleRate;
+    double wa = (2.0 / T) * tan(wd * T / 2.0);
+    double gCoeff = wa * T / 2.0;
+    double gp1 = 1.0 + gCoeff;
+
+    // Calculate "Big G" coefficients (feedback path gains)
+    G4 = 0.5 * gCoeff / gp1;
+    G3 = 0.5 * gCoeff / (gp1 - 0.5 * gCoeff * G4);
+    G2 = 0.5 * gCoeff / (gp1 - 0.5 * gCoeff * G3);
+    G1 = gCoeff / (gp1 - gCoeff * G2);
+
+    // Product of all G's
+    GAMMA = G4 * G3 * G2 * G1;
+
+    // Sigma gain coefficients
+    SG1 = G4 * G3 * G2;
+    SG2 = G4 * G3;
+    SG3 = G4;
+    SG4 = 1.0;
+
+    // One-pole alpha coefficient
+    alpha = gCoeff / gp1;
+
+    // Alpha for 1st stage (one octave above, like TB-303). The octave-up pole
+    // reaches Nyquist at half the cutoff the other poles do, so at very high
+    // cutoff (and low sample rates) its prewarp argument can exceed pi/2, where
+    // tan() goes negative and the stage becomes unstable. Clamp the argument to a
+    // safe fraction of Nyquist - only engages at extreme cutoff, no effect
+    // otherwise.
+    const double MAX_POLE_ARG = 1.4;   // < pi/2 (1.5708)
+    double octArg = std::clamp(2*wd * T / 2.0, 0.0, MAX_POLE_ARG);
+    double wa2 = (2.0 / T) * tan(octArg);
+    double g2 = wa2 * T / 2.0;
+    alpha2 = g2 / (1.0 + g2);
+
+    // Beta coefficients
+    beta1 = 1.0 / (gp1 - gCoeff * G2);
+    beta2 = 1.0 / (gp1 - 0.5 * gCoeff * G3);
+    beta3 = 1.0 / (gp1 - 0.5 * gCoeff * G4);
+    beta4 = 1.0 / gp1;
+
+    // Gamma coefficients (local feedback)
+    gamma1 = 1.0 + G1 * G2;
+    gamma2 = 1.0 + G2 * G3;
+    gamma3 = 1.0 + G3 * G4;
+
+    // Delta coefficients
+    delta1 = gCoeff;
+    delta2 = 0.5 * gCoeff;
+    delta3 = 0.5 * gCoeff;
+
+    // Epsilon coefficients
+    epsilon1 = G2;
+    epsilon2 = G3;
+    epsilon3 = G4;
+
+    // Feedback factor; K = 17 is the diode-ladder self-oscillation point. Plain
+    // Diode reaches it at full resonance. Octave mode is capped at
+    // OCTAVE_RESONANCE_CEILING, scaled by driveMakeup (drive-invariance: drive
+    // raises the loop's small-signal gain by driveFactor^DRIVE_MAKEUP_EXP, which
+    // driveMakeup cancels), and scaled by resonance tracking so its Q rises with
+    // cutoff like the TeeBee.
+    if (octaveMode)
+    {
+      double resTrack = pow(cutoff / OCTAVE_RES_TRACK_REF, OCTAVE_RES_TRACK_EXP);
+      // Effective resonance (no driveMakeup yet), soft-knee-limited, then converted to
+      // the actual feedback coefficient via driveMakeup. Because physical resonance =
+      // K * loop-gain = effK, the soft knee below bounds it at OCTAVE_K_CEIL regardless
+      // of drive, so the coupling below can push toward self-osc without running away.
+      double effK = 17.0 * resonance * OCTAVE_RESONANCE_CEILING * resTrack;
+      // Drive above the calibration reference pushes resonance up the knee; floored at
+      // 1.0 below it so lower drive leaves resonance at the 0.5-calibrated value.
+      effK *= pow(std::max(driveFactor, OCTAVE_RES_DRIVE_REF) / OCTAVE_RES_DRIVE_REF,
+                  OCTAVE_RES_DRIVE_EXP);
+      if (effK > OCTAVE_K_KNEE)
+      {
+        double span = OCTAVE_K_CEIL - OCTAVE_K_KNEE;
+        effK = OCTAVE_K_KNEE + span * tanh((effK - OCTAVE_K_KNEE) / span);
+      }
+      K = effK * driveMakeup;
+    }
+    else
+    {
+      K = 17.0 * resonance;
+    }
+  }
+
+  INLINE double DiodeLadderFilter::shape(double x)
+  {
+    // Soft clipping - tanh approximation
+    return math_approx::tanh<7>(x);
+  }
+
+  INLINE double DiodeLadderFilter::getSample(double in)
+  {
+    // Safety: if the ladder state ever goes non-finite (extreme cutoff/feedback
+    // modulation), reset it so the filter self-heals instead of latching to
+    // permanent silence via propagating NaN/Inf.
+    if (!std::isfinite(z1 + z2 + z3 + z4))
+      z1 = z2 = z3 = z4 = 0.0;
+
+    // Input without compensation - compensation applied at output
+    double input = in;
+
+    // Calculate feedback signals (S4 -> S3 -> S2 -> S1)
+    double S4 = beta4 * z4;
+    double S3 = beta3 * (z3 + S4 * delta3);
+    double S2 = beta2 * (z2 + S3 * delta2);
+    double S1 = beta1 * (z1 + S2 * delta1);
+
+    // SIGMA - weighted sum of feedback signals
+    double SIGMA = SG1 * S1 + SG2 * S2 + SG3 * S3 + SG4 * S4;
+
+    // Form input to the ladder (with feedback)
+    double un = (input - K * SIGMA) / (1.0 + K * GAMMA);
+
+    // Apply input nonlinearity with headroom scaling: scale down before the
+    // tanh and back up after, so 0 dB drive (driveFactor == 1) stays clean
+    // and turning up the drive pushes the signal into saturation. Matches the
+    // DB303 shaper so the 0..9 dB range feels the same.
+    // driveMakeup is the level compensation (see setInputDrive): without it the
+    // pre-tanh driveFactor gain doubles as a volume boost, so the drive knob
+    // acted as a loudness control. It keeps drive roughly level-neutral while the
+    // tanh still saturates peaks - so drive changes timbre/resonance-compression,
+    // not overall level.
+    un = shape(driveFactor * un * headroomBias) * driveMakeup / headroomBias;
+
+    // 1st stage (optionally one octave above for TB-303 style slope)
+    double xin = un * gamma1 + S2 + epsilon1 * S1;
+    double v = (a1 * xin - z1) * (octaveMode ? alpha2 : alpha);
+    double lp = v + z1;
+    z1 = lp + v;
+
+    // 2nd stage
+    xin = lp * gamma2 + S3 + epsilon2 * S2;
+    v = (a2 * xin - z2) * alpha;
+    lp = v + z2;
+    z2 = lp + v;
+
+    // 3rd stage
+    xin = lp * gamma3 + S4 + epsilon3 * S3;
+    v = (a3 * xin - z3) * alpha;
+    lp = v + z3;
+    z3 = lp + v;
+
+    // 4th stage
+    v = (a4 * lp - z4) * alpha;
+    lp = v + z4;
+    z4 = lp + v;
+
+    // Oberheim variations
+    // return c.mA * dU + c.mB * dLP1 + c.mC * dLP2 + c.mD * dLP3 +  c.mE * dLP4;
+
+    // Apply passband gain compensation at output (keeps saturation independent of compensation)
+    return lp * (1.0 + passbandCompensation * K);
+  }
+
+} // end namespace dfl
+
+#endif // dfl_DiodeLadderFilter_h

--- a/src/dsp/open303/rosic_Open303.cpp
+++ b/src/dsp/open303/rosic_Open303.cpp
@@ -140,11 +140,16 @@ void Open303::setFilterType(FilterType newType)
 {
   currentFilterType = newType;
 
-  // Configure diode filter octave mode based on filter type
-  if(currentFilterType == FILTER_DIODE_OCTAVE)
-    diodeFilter.setOctaveMode(true);
-  else
-    diodeFilter.setOctaveMode(false);
+  // Octave mode (steeper 1st pole) applies only to the plain-LP Diode Octave
+  // model. The BP/HP response modes are plain-diode only.
+  diodeFilter.setOctaveMode(newType == FILTER_DIODE_OCTAVE);
+
+  int response = DiodeLadderFilter::RESPONSE_LP;
+  if(newType == FILTER_DIODE_BP)
+    response = DiodeLadderFilter::RESPONSE_BP;
+  else if(newType == FILTER_DIODE_HP)
+    response = DiodeLadderFilter::RESPONSE_HP;
+  diodeFilter.setResponseMode(response);
 }
 
 void Open303::setFilterDrive(double newDriveDb)

--- a/src/dsp/open303/rosic_Open303.cpp
+++ b/src/dsp/open303/rosic_Open303.cpp
@@ -29,6 +29,7 @@ Open303::Open303()
   noteOffCountDown =     0;
   slideToNextNote  = false;
   idle             = true;
+  currentFilterType = FILTER_TEEBEE;
 
   // LFO defaults
   lfoDepth         =    0.0;
@@ -104,6 +105,7 @@ void Open303::setSampleRate(double newSampleRate)
 
   oscillator.setSampleRate    (  oversampling*newSampleRate);
   filter.setSampleRate        (  oversampling*newSampleRate);
+  diodeFilter.setSampleRate   (  oversampling*newSampleRate);
   sampleRate = newSampleRate;
 }
 
@@ -111,6 +113,53 @@ void Open303::setCutoff(double newCutoff)
 {
   cutoff = newCutoff;
   calculateEnvModScalerAndOffset();
+}
+
+void Open303::setResonance(double newResonance)
+{
+  // newResonance is a percentage (0..100). The TeeBee filter takes percent
+  // directly and skews/normalizes it internally; the diode filter expects a
+  // normalized, pre-skewed 0..1 value (K = 17*resonance, self-oscillation ~17).
+  double normalizedResonance = 0.01 * newResonance;               // 0..100 -> 0..1
+
+  // Match the TeeBee's resonance skew so the knob tracks the same curve on both
+  // models: use the TeeBee's saturating-exponential map (see
+  // TeeBeeFilter::setResonance) instead of a cubic, so the resonance comes up on
+  // the same curve rather than staying flat then spiking. At knob = 100 this
+  // reaches 1.0, driving the diode's K to its self-oscillation point (17).
+  // The Diode Octave model is pulled back below self-oscillation to match the
+  // TeeBee - that ceiling lives in DiodeLadderFilter (octave-mode only), so
+  // plain Diode still self-oscillates at full knob.
+  double skewedResonance = (1.0 - exp(-3.0*normalizedResonance)) / (1.0 - exp(-3.0));
+
+  filter.setResonance(newResonance);
+  diodeFilter.setResonance(skewedResonance);
+}
+
+void Open303::setFilterType(FilterType newType)
+{
+  currentFilterType = newType;
+
+  // Configure diode filter octave mode based on filter type
+  if(currentFilterType == FILTER_DIODE_OCTAVE)
+    diodeFilter.setOctaveMode(true);
+  else
+    diodeFilter.setOctaveMode(false);
+}
+
+void Open303::setFilterDrive(double newDriveDb)
+{
+  // The diode ladder saturates its input (see DiodeLadderFilter::getSample),
+  // so drive changes its timbre. TeeBee is linear in TB_303 mode - the call
+  // is harmless there but has no audible effect.
+  filter.setDrive(newDriveDb);
+  diodeFilter.setInputDrive(newDriveDb);
+}
+
+void Open303::setPassbandCompensation(double newCompensation)
+{
+  // Diode-ladder-only: TeeBee has no passband compensation.
+  diodeFilter.setPassbandCompensation(newCompensation);
 }
 
 void Open303::setEnvMod(double newEnvMod)
@@ -223,6 +272,7 @@ void Open303::triggerNote(int noteNumber, bool hasAccent)
   {
     oscillator.resetPhase();
     filter.reset();
+    diodeFilter.reset();
     highpass1.reset();
     highpass2.reset();
     allpass.reset();

--- a/src/dsp/open303/rosic_Open303.h
+++ b/src/dsp/open303/rosic_Open303.h
@@ -29,6 +29,8 @@ namespace rosic
     FILTER_TEEBEE = 0,      // Original TB-303 transistor ladder
     FILTER_DIODE_OCTAVE,    // Diode ladder with 1st pole one octave above (~18dB/oct)
     FILTER_DIODE,           // Diode ladder (4-pole, 24dB/oct)
+    FILTER_DIODE_BP,        // Diode ladder, bandpass response (12/12 dB/oct)
+    FILTER_DIODE_HP,        // Diode ladder, highpass response (24 dB/oct)
     NUM_FILTER_TYPES
   };
 

--- a/src/dsp/open303/rosic_Open303.h
+++ b/src/dsp/open303/rosic_Open303.h
@@ -6,6 +6,7 @@
 #include "rosic_BlendOscillator.h"
 #include "rosic_BiquadFilter.h"
 #include "rosic_TeeBeeFilter.h"
+#include "dfl_DiodeLadderFilter.h"
 #include "rosic_AnalogEnvelope.h"
 #include "rosic_DecayEnvelope.h"
 #include "rosic_LeakyIntegrator.h"
@@ -19,6 +20,17 @@ using namespace std; // for the noteList
 
 namespace rosic
 {
+  // Import dfl classes
+  using dfl::DiodeLadderFilter;
+
+  /** Filter types available for selection. */
+  enum FilterType
+  {
+    FILTER_TEEBEE = 0,      // Original TB-303 transistor ladder
+    FILTER_DIODE_OCTAVE,    // Diode ladder with 1st pole one octave above (~18dB/oct)
+    FILTER_DIODE,           // Diode ladder (4-pole, 24dB/oct)
+    NUM_FILTER_TYPES
+  };
 
   /**
 
@@ -58,7 +70,23 @@ namespace rosic
     void setCutoff(double newCutoff);
 
     /** Sets the resonance amount for the filter. */
-    void setResonance(double newResonance) { filter.setResonance(newResonance); }
+    void setResonance(double newResonance);
+
+    /** Sets the filter type. */
+    void setFilterType(FilterType newType);
+
+    /** Sets the filter input drive in decibels. Pushes the signal into the
+    diode ladder's saturating nonlinearity for overdrive character. The TeeBee
+    filter is linear in TB_303 mode, so this only affects the diode models. */
+    void setFilterDrive(double newDriveDb);
+
+    /** Returns the current filter type. */
+    FilterType getFilterType() const { return currentFilterType; }
+
+    /** Sets the diode filter's passband (bass) compensation, 0..1. Boosts the
+    low end to offset the thinning that the diode ladder exhibits at high
+    resonance. Only affects the diode filter models. */
+    void setPassbandCompensation(double newCompensation);
 
     /** Sets the modulation depth of the filter's cutoff frequency by the filter-envelope generator
     (in percent). */
@@ -256,6 +284,7 @@ namespace rosic
     MipMappedWaveTable        waveTable1, waveTable2;
     BlendOscillator           oscillator;
     TeeBeeFilter              filter;
+    DiodeLadderFilter         diodeFilter;
     AnalogEnvelope            ampEnv;
     DecayEnvelope             mainEnv;
     LeakyIntegrator           pitchSlewLimiter;
@@ -324,6 +353,7 @@ namespace rosic
     int    noteOffCountDown; // a countdown variable till next note-off in sequencer mode
     bool   slideToNextNote;  // indicate that we need to slide to the next note in sequencer mode
     bool   idle;             // flag to indicate that we have currently nothing to do in getSample
+    FilterType currentFilterType;  // currently selected filter type
 
     // LFO modulation depth
     double lfoDepth;    // LFO depth (-1.0 to +1.0)
@@ -425,6 +455,7 @@ namespace rosic
     tmp2 = accentGain*tmp2;
     double instCutoff = cutoff * pow(2.0, tmp1+tmp2+lfoFilterMod);
     filter.setCutoff(instCutoff);
+    diodeFilter.setCutoff(instCutoff);
 
     double ampEnvOut = ampEnv.getSample();
     //ampEnvOut += 0.45*filterEnvOut + accentGain*6.8*filterEnvOut;
@@ -438,7 +469,11 @@ namespace rosic
     {
       tmp  = -oscillator.getSample();         // the raw oscillator signal
       tmp  = highpass1.getSample(tmp);        // pre-filter highpass
-      tmp  = filter.getSample(tmp);           // now it's filtered
+      // Apply selected filter
+      if(currentFilterType == FILTER_TEEBEE)
+        tmp = filter.getSample(tmp);
+      else
+        tmp = diodeFilter.getSample(tmp);
       tmp  = antiAliasFilter.getSample(tmp);  // anti-aliasing filtered
 
     }

--- a/src/gui/amadeusp/FilterModelSelect.h
+++ b/src/gui/amadeusp/FilterModelSelect.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "Gui.h"
+
+// Compact prev/next selector for the "filterType" AudioParameterChoice
+// (TeeBee / Diode / Diode Octave). Mirrors OverdriveModelSelect, but sized
+// to overlay inside the MODIFICATIONS label cell.
+class FilterModelSelect : public juce::Component,
+                          public juce::AudioProcessorValueTreeState::Listener
+{
+public:
+    FilterModelSelect(juce::AudioProcessorValueTreeState& vts)
+        : valueTreeState(vts)
+    {
+        customFont = juce::Font(juce::Typeface::createSystemTypefaceFor(BinaryData::ErbosDraco1StOpenNbpRegularl5wX_ttf, BinaryData::ErbosDraco1StOpenNbpRegularl5wX_ttfSize));
+        customFont.setHeight(10.0f);
+
+        imageLeftArrow = juce::ImageCache::getFromMemory(BinaryData::leftarrowpresets_png, BinaryData::leftarrowpresets_pngSize);
+        imageRightArrow = juce::ImageCache::getFromMemory(BinaryData::rightarrowpresets_png, BinaryData::rightarrowpresets_pngSize);
+
+        addAndMakeVisible(modelName);
+        addAndMakeVisible(prevButton);
+        addAndMakeVisible(nextButton);
+
+        modelName.setFont(customFont);
+        modelName.setJustificationType(juce::Justification::centred);
+        modelName.setColour(juce::Label::textColourId, juce::Colours::lightgrey);
+        modelName.setInterceptsMouseClicks(false, false);
+
+        prevButton.onClick = [this] { changeIndex(-1); };
+        nextButton.onClick = [this] { changeIndex(1); };
+
+        // Initialise displayed name from the current parameter value
+        if (auto* param = dynamic_cast<juce::AudioParameterChoice*>(valueTreeState.getParameter("filterType")))
+            setModelName(param->choices[param->getIndex()]);
+
+        valueTreeState.addParameterListener("filterType", this);
+    }
+
+    ~FilterModelSelect() override
+    {
+        valueTreeState.removeParameterListener("filterType", this);
+    }
+
+    void changeIndex(int delta)
+    {
+        if (auto* param = dynamic_cast<juce::AudioParameterChoice*>(valueTreeState.getParameter("filterType")))
+        {
+            int numChoices = param->choices.size();
+            // Wrap around so the selector is circular: left from the first
+            // choice lands on the last, right from the last lands on the first.
+            int newValue = (param->getIndex() + delta + numChoices) % numChoices;
+            param->beginChangeGesture();
+            *param = newValue;
+            param->endChangeGesture();
+        }
+    }
+
+    void parameterChanged(const juce::String& parameterID, float newValue) override
+    {
+        if (parameterID == "filterType")
+        {
+            if (auto* param = dynamic_cast<juce::AudioParameterChoice*>(valueTreeState.getParameter("filterType")))
+                setModelName(param->choices[static_cast<int>(newValue)]);
+        }
+    }
+
+    void setModelName(const juce::String& name)
+    {
+        modelName.setText(name, juce::dontSendNotification);
+    }
+
+    void resized() override
+    {
+        const int arrowWidth = 7;
+        prevButton.setBounds(0, 0, arrowWidth, getHeight());
+        nextButton.setBounds(getWidth() - arrowWidth, 0, arrowWidth, getHeight());
+        modelName.setBounds(arrowWidth + 2, 0, getWidth() - 2 * (arrowWidth + 2), getHeight());
+    }
+
+    void paint(juce::Graphics& g) override
+    {
+        paintImageButton(g, prevButton, imageLeftArrow, prevButton.isMouseOver());
+        paintImageButton(g, nextButton, imageRightArrow, nextButton.isMouseOver());
+    }
+
+private:
+    // Draw the arrow image, choosing the normal/hover half of the vertically-split png
+    void paintImageButton(juce::Graphics& g, juce::ImageButton& button, const juce::Image& image, bool isHovered)
+    {
+        int frameHeight = image.getHeight() / 2;
+        int sourceY = isHovered ? frameHeight : 0;
+        g.drawImage(image, button.getBounds().getX(), button.getBounds().getY(), button.getWidth(), button.getHeight(),
+                    0, sourceY, image.getWidth(), frameHeight, false);
+    }
+
+    juce::AudioProcessorValueTreeState& valueTreeState;
+    juce::ImageButton prevButton;
+    juce::ImageButton nextButton;
+    juce::Label modelName;
+
+    juce::Font customFont;
+    juce::Image imageLeftArrow;
+    juce::Image imageRightArrow;
+};

--- a/src/gui/amadeusp/Gui.cpp
+++ b/src/gui/amadeusp/Gui.cpp
@@ -20,6 +20,22 @@ JC303Editor::JC303Editor (JC303& p, juce::AudioProcessorValueTreeState& vts)
     addAndMakeVisible(softAttackSlider = createKnob("small"));
     addAndMakeVisible(slideTimeSlider = createKnob("small"));
     addAndMakeVisible(sqrDriverSlider = createKnob("small"));
+    // diode filter mods
+    addAndMakeVisible(filterDriveSlider = createKnob("small"));
+    addAndMakeVisible(bassCompSlider = createKnob("small"));
+    // labels for the diode filter mod knobs (panel has no printed labels here)
+    juce::Font panelFont(juce::Typeface::createSystemTypefaceFor(BinaryData::ErbosDraco1StOpenNbpRegularl5wX_ttf, BinaryData::ErbosDraco1StOpenNbpRegularl5wX_ttfSize));
+    panelFont.setHeight(9.0f);
+    for (auto* label : { &filterDriveLabel, &bassCompLabel })
+    {
+        label->setFont(panelFont);
+        label->setJustificationType(juce::Justification::centred);
+        label->setColour(juce::Label::textColourId, juce::Colours::lightgrey);
+        label->setInterceptsMouseClicks(false, false);
+        addAndMakeVisible(label);
+    }
+    filterDriveLabel.setText("DRIVE", juce::dontSendNotification);
+    bassCompLabel.setText("BASS", juce::dontSendNotification);
     // on/off mod switch
     addAndMakeVisible(switchModButton = createSwitch());
     addAndMakeVisible(ledModButton = createLed("switchModState"));
@@ -31,6 +47,8 @@ JC303Editor::JC303Editor (JC303& p, juce::AudioProcessorValueTreeState& vts)
     addAndMakeVisible(ledOverdriveButton = createLed("switchOverdriveState"));
     // overdrive model select component
     addAndMakeVisible(overdriveModelSelect = new OverdriveModelSelect(valueTreeState, processorRef.getModelListNames()));
+    // filter model selector (MODIFICATIONS section)
+    addAndMakeVisible(filterModelSelect = new FilterModelSelect(valueTreeState));
 
     // Easter egg mr. smile
     addAndMakeVisible(acidSmile);
@@ -51,6 +69,9 @@ JC303Editor::JC303Editor (JC303& p, juce::AudioProcessorValueTreeState& vts)
     softAttackAttachment.reset(new SliderAttachment(valueTreeState, "softAttack", *softAttackSlider));
     slideTimeAttachment.reset(new SliderAttachment(valueTreeState, "slideTime", *slideTimeSlider));
     sqrDriverAttachment.reset(new SliderAttachment(valueTreeState, "sqrDriver", *sqrDriverSlider));
+    // diode filter mods
+    filterDriveAttachment.reset(new SliderAttachment(valueTreeState, "filterDrive", *filterDriveSlider));
+    bassCompAttachment.reset(new SliderAttachment(valueTreeState, "bassComp", *bassCompSlider));
     switchModButtonAttachment.reset(new ButtonAttachment(valueTreeState, "switchModState", *switchModButton));
     // overdrive
     overdriveLevelAttachment.reset(new SliderAttachment(valueTreeState, "overdriveLevel", *overdriveLevelSlider));
@@ -161,9 +182,18 @@ void JC303Editor::setControlsLayout()
     pair<int, int> softAttackLocation = {330, 273};
     pair<int, int> slideTimeLocation = {391, 273};
     pair<int, int> sqrDriverLocation = {452, 273};
+    // diode filter mods (provisional: stacked in the gap after SQUARE DRIVE)
+    pair<int, int> filterDriveLocation = {500, 260};
+    pair<int, int> bassCompLocation = {500, 303};
+    const int filterModLabelWidth = 46;
+    const int filterModLabelHeight = 10;
     // MODs switch
     pair<int, int> switchLocation = {52, 273};
     pair<int, int> modLedLocation = {82, 243};
+    // filter model selector (overlaid in the MODIFICATIONS label cell)
+    pair<int, int> filterModelSelectLocation = {33, 295};
+    const int filterModelSelectWidth = 112;
+    const int filterModelSelectHeight = 20;
     // overdrive
     pair<int, int> overdriveLevelLocation = {566, 273};
     pair<int, int> overdriveDryWetLocation = {749, 273};
@@ -192,6 +222,12 @@ void JC303Editor::setControlsLayout()
     softAttackSlider->setBounds(softAttackLocation.first, softAttackLocation.second, sliderSmallSize, sliderSmallSize);
     slideTimeSlider->setBounds(slideTimeLocation.first, slideTimeLocation.second, sliderSmallSize, sliderSmallSize);
     sqrDriverSlider->setBounds(sqrDriverLocation.first, sqrDriverLocation.second, sliderSmallSize, sliderSmallSize);
+    // diode filter mods (label centred above each knob)
+    filterDriveSlider->setBounds(filterDriveLocation.first, filterDriveLocation.second, sliderSmallSize, sliderSmallSize);
+    bassCompSlider->setBounds(bassCompLocation.first, bassCompLocation.second, sliderSmallSize, sliderSmallSize);
+    const int filterDriveCentreX = filterDriveLocation.first + sliderSmallSize / 2;
+    filterDriveLabel.setBounds(filterDriveCentreX - filterModLabelWidth / 2, filterDriveLocation.second - filterModLabelHeight - 1, filterModLabelWidth, filterModLabelHeight);
+    bassCompLabel.setBounds(filterDriveCentreX - filterModLabelWidth / 2, bassCompLocation.second - filterModLabelHeight - 1, filterModLabelWidth, filterModLabelHeight);
     switchModButton->setBounds(switchLocation.first, switchLocation.second, switchWidth, switchHeight);
     ledModButton->setBounds(modLedLocation.first, modLedLocation.second, ledWidth, ledHeight);
     // overdrive
@@ -200,6 +236,7 @@ void JC303Editor::setControlsLayout()
     switchOverdriveButton->setBounds(overdriveSwitchLocation.first, overdriveSwitchLocation.second, switchWidth, switchHeight);
     ledOverdriveButton ->setBounds(overdriveLedLocation.first, overdriveLedLocation.second, ledWidth, ledHeight);
     overdriveModelSelect->setBounds(overdriveModelSelectLocation.first, overdriveModelSelectLocation.second, selectModellWidth, selectModelHeight);
+    filterModelSelect->setBounds(filterModelSelectLocation.first, filterModelSelectLocation.second, filterModelSelectWidth, filterModelSelectHeight);
 
     // Easter egg mr. smile
     acidSmile.setBounds(acidSmileLocation.first, acidSmileLocation.second, acidSmileWidth, acidSmileHeight);

--- a/src/gui/amadeusp/Gui.h
+++ b/src/gui/amadeusp/Gui.h
@@ -6,6 +6,7 @@
 #include "SwitchButton.h"
 #include "SwitchLed.h"
 #include "OverdriveModelSelect.h"
+#include "FilterModelSelect.h"
 #include "AcidSmile.h"
 
 typedef juce::AudioProcessorValueTreeState::SliderAttachment SliderAttachment;
@@ -48,6 +49,11 @@ private:
     juce::Slider* softAttackSlider;
     juce::Slider* slideTimeSlider;
     juce::Slider* sqrDriverSlider;
+    // diode filter mods
+    juce::Slider* filterDriveSlider;
+    juce::Slider* bassCompSlider;
+    juce::Label filterDriveLabel;
+    juce::Label bassCompLabel;
     SwitchButton* switchModButton;
     SwitchLed* ledModButton;
     // overdrive
@@ -72,6 +78,9 @@ private:
     std::unique_ptr<SliderAttachment> softAttackAttachment;
     std::unique_ptr<SliderAttachment> slideTimeAttachment;
     std::unique_ptr<SliderAttachment> sqrDriverAttachment;
+    // diode filter mods
+    std::unique_ptr<SliderAttachment> filterDriveAttachment;
+    std::unique_ptr<SliderAttachment> bassCompAttachment;
     std::unique_ptr<ButtonAttachment> switchModButtonAttachment;
     // overdrive
     std::unique_ptr<SliderAttachment> overdriveLevelAttachment;
@@ -79,6 +88,8 @@ private:
     std::unique_ptr<ButtonAttachment> switchOverdriveButtonAttachment;
     // previous, next buttons and model name display component
     OverdriveModelSelect* overdriveModelSelect;
+    // filter model selector (overlaid in the MODIFICATIONS cell)
+    FilterModelSelect* filterModelSelect;
 
     // our value tree state
     juce::AudioProcessorValueTreeState& valueTreeState;


### PR DESCRIPTION
Adds **bandpass** and **highpass** response modes to the Pirkle diode ladder filter from #33.

> **Stacked on #33** — please merge that first. Until then this PR's diff includes #33's diode-filter commit; once #33 lands in `develop`, this collapses to just the 4 BP/HP commits.

## What's new
- **`Diode BP` and `Diode HP`** entries in the Filter Model selector, alongside `Diode` / `Diode Octave`.
- Synthesised by **Oberheim-style pole mixing** of the ladder's per-stage taps — same 4-pole core, no extra state.

## Provenance of the pole-mixing (Oberheim variations)
Deriving multiple responses (LP/BP/HP/notch) from a single lowpass ladder by taking a **weighted sum of the per-stage taps** is the classic *"Oberheim variations"* technique — named after the Oberheim Xpander / Matrix-12, whose filters exposed many response types from one 4-pole ladder this way. For an ideal cascade of identical one-pole sections the tap weights are the binomial coefficients of `(1 − G)ⁿ`:

- LP (24 dB/oct): `lp4`
- BP (12/12): `lp2 − 2·lp3 + lp4`
- HP (24 dB/oct): `un − 4·lp1 + 6·lp2 − 4·lp3 + lp4`

References:
- Will Pirkle, *Designing Software Synthesizer Plug-Ins in C++* — the same source as the diode ladder itself (#33).
- The identical coefficients already live in this project in `rosic::TeeBeeFilter` (Robin Schmidt's Open303), in its `LP_*/HP_*/BP_*` mode table — this PR reuses that exact scheme for the diode ladder.

## HP normalization (deviation from the textbook coefficients)
The binomial HP above assumes each tap is a unity-gain cascade power (`lpᵢ = un·Gⁱ`). This diode topology's `a2..a4 = 0.5` stage scaling breaks that, so DC failed to cancel and the low end leaked at ~3.7×. Measuring the per-tap DC gains showed the fix is scaling the lowpass-reconstruction term by exactly **1/5** (verified independent of cutoff and resonance — it's fixed by the a-coefficients):

`HP = un − 0.2·(4·lp1 − 6·lp2 + 4·lp3 − lp4)`

Result: DC leak 3.72 → 0.10; HP passband now matches LP within ~2%.

## HP-mode knob behaviour
- The `bassComp` knob (bass makeup) is meaningless for HP, so it's **bypassed** there (no more resonance-dependent broadband boost running HP hot).
- That freed knob is **repurposed as an HP→LP morph**: 0 = pure highpass, 1 = pure lowpass. LP/BP keep it as bass compensation.

## Notes
- Plain-diode only (no octave BP/HP variants).
- Verified with an offline sine-sweep magnitude probe through the real filter across resonance 0–0.9 and cutoff 200 Hz–15 kHz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)