### PR TITLE
Add mute and hammer step behaviors to the Open303 engine

### DIFF
--- a/src/dsp/open303/rosic_AcidPattern.h
+++ b/src/dsp/open303/rosic_AcidPattern.h
@@ -23,6 +23,8 @@ namespace rosic
     bool accent;
     bool slide;
     bool gate;
+    bool mute;    // TT-303 extension: choked note (shorter gate, darker, quieter)
+    bool hammer;  // TT-303 extension: legato with instant pitch change (no glide)
 
     AcidNote()
     {
@@ -31,10 +33,12 @@ namespace rosic
       accent = false;
       slide  = false;
       gate   = false;
+      mute   = false;
+      hammer = false;
     }
 
     bool isInDefaultState()
-    { return key == 0 && octave == 0 && accent == false && slide == false && gate == false; }
+    { return key == 0 && octave == 0 && accent == false && slide == false && gate == false && mute == false && hammer == false; }
 
   };
 
@@ -77,6 +81,12 @@ namespace rosic
     /** Sets the gate flag for one of the steps. */
     void setGate(int step, bool shouldBeOpen) { notes[step].gate = shouldBeOpen; }
 
+    /** Sets the mute flag for one of the steps (TT-303 extension). */
+    void setMute(int step, bool shouldBeMuted) { notes[step].mute = shouldBeMuted; }
+
+    /** Sets the hammer flag for one of the steps (TT-303 extension). */
+    void setHammer(int step, bool shouldHaveHammer) { notes[step].hammer = shouldHaveHammer; }
+
     /** Clears all notes in the pattern. */
     void clear();
 
@@ -117,6 +127,12 @@ namespace rosic
 
     /** Returns the gate flag for one of the steps. */
     bool getGate(int step) const { return notes[step].gate; }
+
+    /** Returns the mute flag for one of the steps (TT-303 extension). */
+    bool getMute(int step) const { return notes[step].mute; }
+
+    /** Returns the hammer flag for one of the steps (TT-303 extension). */
+    bool getHammer(int step) const { return notes[step].hammer; }
 
     /** Returns the maximum number of steps. */
     static int getMaxNumSteps() { return maxNumSteps; }

--- a/src/dsp/open303/rosic_AcidSequencer.cpp
+++ b/src/dsp/open303/rosic_AcidSequencer.cpp
@@ -50,6 +50,18 @@ void AcidSequencer::toggleKeyPermissibility(int key)
     keyPermissible[key] = !keyPermissible[key];
 }
 
+void AcidSequencer::setMute(int pattern, int step, bool shouldBeMuted)
+{
+  if( pattern >= 0 && pattern < numPatterns )
+    patterns[pattern].setMute(step, shouldBeMuted);
+}
+
+void AcidSequencer::setHammer(int pattern, int step, bool shouldHaveHammer)
+{
+  if( pattern >= 0 && pattern < numPatterns )
+    patterns[pattern].setHammer(step, shouldHaveHammer);
+}
+
 //-------------------------------------------------------------------------------------------------
 // inquiry:
 

--- a/src/dsp/open303/rosic_AcidSequencer.h
+++ b/src/dsp/open303/rosic_AcidSequencer.h
@@ -59,6 +59,12 @@ namespace rosic
     /** Sets the gate flag for one of the steps. */
     void setGate(int pattern, int step, bool shouldBeOpen);
 
+    /** Sets the mute flag for one of the steps (TT-303 extension). */
+    void setMute(int pattern, int step, bool shouldBeMuted);
+
+    /** Sets the hammer flag for one of the steps (TT-303 extension). */
+    void setHammer(int pattern, int step, bool shouldHaveHammer);
+
     /** Selects one of the modes for the sequencer @see sequencerModes. */
     void setMode(int newMode);
 

--- a/src/dsp/open303/rosic_Open303.cpp
+++ b/src/dsp/open303/rosic_Open303.cpp
@@ -28,7 +28,15 @@ Open303::Open303()
   currentVel       =     0;
   noteOffCountDown =     0;
   slideToNextNote  = false;
+  hammerToNextNote = false;
   idle             = true;
+  currentNoteMuted = false;
+
+  // TT-303 mute parameters (conservative defaults)
+  muteGateFactor   =     0.5;   // 50% gate length
+  muteLevelFactor  =     0.6;   // 60% volume
+  muteCutoffFactor =     0.7;   // 70% cutoff
+  muteEnvFactor    =     0.7;   // 70% envelope mod
 
   setEnvMod(25.0);
 
@@ -249,6 +257,29 @@ void Open303::slideToNote(int noteNumber, bool hasAccent)
 {
   oscFreq = pitchToFreq(noteNumber, tuning);
 
+  if( hasAccent )
+  {
+    accentGain = accent;
+    setMainEnvDecay(accentDecay);
+    ampEnv.setRelease(accentAmpRelease);
+  }
+  else
+  {
+    accentGain = 0.0;
+    setMainEnvDecay(normalDecay);
+    ampEnv.setRelease(normalAmpRelease);
+  }
+  idle = false;
+}
+
+void Open303::hammerToNote(int noteNumber, bool hasAccent)
+{
+  // Hammer is like slide but with instant pitch change (no portamento)
+  // Set frequency AND immediately set slew limiter state to avoid any glide
+  oscFreq = pitchToFreq(noteNumber, tuning);
+  pitchSlewLimiter.setState(oscFreq);  // Instant pitch change, no slew
+
+  // Handle accent (same as slideToNote)
   if( hasAccent )
   {
     accentGain = accent;

--- a/src/dsp/open303/rosic_Open303.h
+++ b/src/dsp/open303/rosic_Open303.h
@@ -261,7 +261,11 @@ namespace rosic
     used). */
     void slideToNote(int noteNumber, bool hasAccent);
 
-    /** Releases a note (called either directly in noteOn or in getSample when the sequencer is 
+    /** Hammers to a note - legato with instant pitch change, no envelope retrigger
+    (TT-303 extension, called in getSample when the sequencer is used). */
+    void hammerToNote(int noteNumber, bool hasAccent);
+
+    /** Releases a note (called either directly in noteOn or in getSample when the sequencer is
     used). */
     void releaseNote(int noteNumber);
 
@@ -306,7 +310,15 @@ namespace rosic
     int    currentVel;       // velocity of currently played note
     int    noteOffCountDown; // a countdown variable till next note-off in sequencer mode
     bool   slideToNextNote;  // indicate that we need to slide to the next note in sequencer mode
+    bool   hammerToNextNote; // indicate that we need to hammer (legato w/ instant pitch) to the next note
     bool   idle;             // flag to indicate that we have currently nothing to do in getSample
+    bool   currentNoteMuted; // flag indicating the current note is muted (shorter gate, darker, quieter)
+
+    // TT-303 mute parameters
+    double muteGateFactor;   // gate length multiplier for muted notes (0.4-0.6)
+    double muteLevelFactor;  // VCA level factor for muted notes (0.4-0.7)
+    double muteCutoffFactor; // filter cutoff factor for muted notes (0.6-0.9)
+    double muteEnvFactor;    // envelope mod factor for muted notes (0.6-0.9)
 
     list<MidiNoteEvent> noteList;
 
@@ -337,21 +349,41 @@ namespace rosic
           int key = note->key + 12*note->octave + currentNote;
           key = clip(key, 0, 127);
 
-          if( !slideToNextNote )
-            triggerNote(key, note->accent);
-          else
-            slideToNote(key, note->accent);
+          // Determine accent: mute overrides accent (muted notes are never accented)
+          bool hasAccent = note->accent && !note->mute;
 
+          // Handle note triggering based on previous step's legato state
+          if( !slideToNextNote && !hammerToNextNote )
+            triggerNote(key, hasAccent);
+          else if( hammerToNextNote )
+            hammerToNote(key, hasAccent);  // Instant pitch, no envelope retrigger
+          else
+            slideToNote(key, hasAccent);   // Glide pitch, no envelope retrigger
+
+          // Track if this note is muted (for cutoff/level reduction in audio processing)
+          currentNoteMuted = note->mute;
+
+          // Determine legato behavior for next step transition
           AcidNote* nextNote = sequencer.getNextScheduledNote();
-          if( note->slide && nextNote->gate == true )
+          bool nextHasGate = nextNote->gate == true;
+
+          // slide and hammer both create legato (continuous gate, no env retrigger)
+          // slide = smooth pitch glide, hammer = instant pitch change
+          if( (note->slide || note->hammer) && nextHasGate )
           {
-            noteOffCountDown = INT_MAX;
-            slideToNextNote  = true;
+            noteOffCountDown = INT_MAX;  // Keep gate open
+            slideToNextNote  = note->slide && !note->hammer;  // slide takes precedence only if no hammer
+            hammerToNextNote = note->hammer;
           }
           else
           {
-            noteOffCountDown = sequencer.getStepLengthInSamples();
+            // Calculate gate length - muted notes have shorter gate
+            int gateLength = sequencer.getStepLengthInSamples();
+            if( note->mute )
+              gateLength = (int)(gateLength * muteGateFactor);
+            noteOffCountDown = gateLength;
             slideToNextNote  = false;
+            hammerToNextNote = false;
           }
         }
       }
@@ -372,7 +404,16 @@ namespace rosic
     tmp2 = n2 * rc2.getSample(tmp2);  
     tmp1 = envScaler * ( tmp1 - envOffset );  // seems not to work yet
     tmp2 = accentGain*tmp2;
-    double instCutoff = cutoff * pow(2.0, tmp1+tmp2);
+
+    // Apply mute envelope reduction if note is muted
+    if( currentNoteMuted )
+      tmp1 *= muteEnvFactor;
+
+    // Apply mute cutoff reduction if note is muted (darker tone)
+    double instCutoff = cutoff;
+    if( currentNoteMuted )
+      instCutoff *= muteCutoffFactor;
+    instCutoff *= pow(2.0, tmp1+tmp2);
     filter.setCutoff(instCutoff);
 
     double ampEnvOut = ampEnv.getSample();
@@ -399,6 +440,10 @@ namespace rosic
     tmp  = notch.getSample(tmp);
     tmp *= ampEnvOut;                       // amplified
     tmp *= ampScaler;
+
+    // Apply mute level reduction if note is muted (quieter tone)
+    if( currentNoteMuted )
+      tmp *= muteLevelFactor;
 
     // find out whether we may switch ourselves off for the next call:
     idle = false;


### PR DESCRIPTION
## What

Adds two per-step behaviors to the Open303 DSP engine (`src/dsp/open303`): **mute** and **hammer**. This is an engine-only change (no GUI/parameter wiring) that extends the internal `AcidSequencer`/`AcidNote` model and the `Open303` voice. Based on `main` so it applies as a single clean commit.

## Concepts

Both are new boolean flags on `AcidNote`:

- **mute** — a *choked note*, not silence. The step still gates and plays, but weaker and darker. On a muted note four things are scaled:

  | effect | factor |
  |---|---|
  | shorter gate | `muteGateFactor = 0.5` |
  | lower env mod | `muteEnvFactor = 0.7` |
  | darker cutoff | `muteCutoffFactor = 0.7` |
  | quieter VCA | `muteLevelFactor = 0.6` |

  Mute also overrides accent — a muted note is never accented (`accent && !mute`).

- **hammer** — legato like slide (gate stays open, envelope not retriggered) but with an **instant** pitch change instead of portamento, via a new `hammerToNote()` that snaps the pitch slew limiter to the target frequency. When both slide and hammer are set, hammer wins.

## Changes

- `rosic_AcidPattern.h` — `mute`/`hammer` fields on `AcidNote`, constructor defaults, `isInDefaultState`, and get/set accessors.
- `rosic_AcidSequencer.{h,cpp}` — `setMute()` / `setHammer()`.
- `rosic_Open303.{h,cpp}` — `hammerToNote()`, mute parameters + defaults, and sequencer trigger routing (trigger / slide / hammer) with mute-based gate/cutoff/env/level reduction.

## Testing

The engine translation units compile cleanly under `clang++ -std=c++17 -fsyntax-only`.