### PR TITLE
feat: mute and hammer steps to sound engine (TT-303 inspired)

### DIFF
--- a/src/dsp/open303/rosic_AcidPattern.h
+++ b/src/dsp/open303/rosic_AcidPattern.h
@@ -23,6 +23,8 @@ namespace rosic
     bool accent;
     bool slide;
     bool gate;
+    bool mute;    // TT-303 extension: choked note (shorter gate, darker, quieter)
+    bool hammer;  // TT-303 extension: legato with instant pitch change (no glide)
 
     AcidNote()
     {
@@ -31,10 +33,12 @@ namespace rosic
       accent = false;
       slide  = false;
       gate   = false;
+      mute   = false;
+      hammer = false;
     }
 
     bool isInDefaultState()
-    { return key == 0 && octave == 0 && accent == false && slide == false && gate == false; }
+    { return key == 0 && octave == 0 && accent == false && slide == false && gate == false && mute == false && hammer == false; }
 
   };
 
@@ -77,6 +81,12 @@ namespace rosic
     /** Sets the gate flag for one of the steps. */
     void setGate(int step, bool shouldBeOpen) { notes[step].gate = shouldBeOpen; }
 
+    /** Sets the mute flag for one of the steps (TT-303 extension). */
+    void setMute(int step, bool shouldBeMuted) { notes[step].mute = shouldBeMuted; }
+
+    /** Sets the hammer flag for one of the steps (TT-303 extension). */
+    void setHammer(int step, bool shouldHaveHammer) { notes[step].hammer = shouldHaveHammer; }
+
     /** Clears all notes in the pattern. */
     void clear();
 
@@ -117,6 +127,12 @@ namespace rosic
 
     /** Returns the gate flag for one of the steps. */
     bool getGate(int step) const { return notes[step].gate; }
+
+    /** Returns the mute flag for one of the steps (TT-303 extension). */
+    bool getMute(int step) const { return notes[step].mute; }
+
+    /** Returns the hammer flag for one of the steps (TT-303 extension). */
+    bool getHammer(int step) const { return notes[step].hammer; }
 
     /** Returns the maximum number of steps. */
     static int getMaxNumSteps() { return maxNumSteps; }

--- a/src/dsp/open303/rosic_AcidSequencer.cpp
+++ b/src/dsp/open303/rosic_AcidSequencer.cpp
@@ -50,6 +50,18 @@ void AcidSequencer::toggleKeyPermissibility(int key)
     keyPermissible[key] = !keyPermissible[key];
 }
 
+void AcidSequencer::setMute(int pattern, int step, bool shouldBeMuted)
+{
+  if( pattern >= 0 && pattern < numPatterns )
+    patterns[pattern].setMute(step, shouldBeMuted);
+}
+
+void AcidSequencer::setHammer(int pattern, int step, bool shouldHaveHammer)
+{
+  if( pattern >= 0 && pattern < numPatterns )
+    patterns[pattern].setHammer(step, shouldHaveHammer);
+}
+
 //-------------------------------------------------------------------------------------------------
 // inquiry:
 

--- a/src/dsp/open303/rosic_AcidSequencer.h
+++ b/src/dsp/open303/rosic_AcidSequencer.h
@@ -59,6 +59,12 @@ namespace rosic
     /** Sets the gate flag for one of the steps. */
     void setGate(int pattern, int step, bool shouldBeOpen);
 
+    /** Sets the mute flag for one of the steps (TT-303 extension). */
+    void setMute(int pattern, int step, bool shouldBeMuted);
+
+    /** Sets the hammer flag for one of the steps (TT-303 extension). */
+    void setHammer(int pattern, int step, bool shouldHaveHammer);
+
     /** Selects one of the modes for the sequencer @see sequencerModes. */
     void setMode(int newMode);
 

--- a/src/dsp/open303/rosic_Open303.cpp
+++ b/src/dsp/open303/rosic_Open303.cpp
@@ -28,7 +28,17 @@ Open303::Open303()
   currentVel       =     0;
   noteOffCountDown =     0;
   slideToNextNote  = false;
+  hammerToNextNote = false;
   idle             = true;
+  currentNoteMuted = false;
+  muteMorph        =   0.0;   // start unmuted
+  muteMorphCoeff   =   0.0;   // will be set in setSampleRate
+
+  // TT-303 mute parameters (conservative defaults)
+  muteGateFactor   =     0.5;   // 50% gate length
+  muteLevelFactor  =     0.6;   // 60% volume
+  muteCutoffFactor =     0.7;   // 70% cutoff
+  muteEnvFactor    =     0.7;   // 70% envelope mod
 
   // LFO defaults
   lfoDepth         =    0.0;
@@ -95,6 +105,10 @@ void Open303::setSampleRate(double newSampleRate)
   rc2.setSampleRate(             (float)newSampleRate);
   sequencer.setSampleRate(              newSampleRate);
   lfo.setSampleRate(                    newSampleRate);
+
+  // Mute morph smoother: ~2ms one-pole so mute level/cutoff/env changes ramp
+  // instead of stepping (avoids clicks at legato hammer/slide boundaries)
+  muteMorphCoeff = exp(-1.0 / (0.002 * newSampleRate));
 
   highpass2.setSampleRate     (         newSampleRate);
   allpass.setSampleRate       (         newSampleRate);
@@ -255,6 +269,29 @@ void Open303::slideToNote(int noteNumber, bool hasAccent)
 {
   oscFreq = pitchToFreq(noteNumber, tuning);
 
+  if( hasAccent )
+  {
+    accentGain = accent;
+    setMainEnvDecay(accentDecay);
+    ampEnv.setRelease(accentAmpRelease);
+  }
+  else
+  {
+    accentGain = 0.0;
+    setMainEnvDecay(normalDecay);
+    ampEnv.setRelease(normalAmpRelease);
+  }
+  idle = false;
+}
+
+void Open303::hammerToNote(int noteNumber, bool hasAccent)
+{
+  // Hammer is like slide but with instant pitch change (no portamento)
+  // Set frequency AND immediately set slew limiter state to avoid any glide
+  oscFreq = pitchToFreq(noteNumber, tuning);
+  pitchSlewLimiter.setState(oscFreq);  // Instant pitch change, no slew
+
+  // Handle accent (same as slideToNote)
   if( hasAccent )
   {
     accentGain = accent;

--- a/src/dsp/open303/rosic_Open303.h
+++ b/src/dsp/open303/rosic_Open303.h
@@ -278,6 +278,10 @@ namespace rosic
     used). */
     void slideToNote(int noteNumber, bool hasAccent);
 
+    /** Hammers to a note - legato with instant pitch change, no envelope retrigger
+    (TT-303 extension, called in getSample when the sequencer is used). */
+    void hammerToNote(int noteNumber, bool hasAccent);
+
     /** Releases a note (called either directly in noteOn or in getSample when the sequencer is
     used). */
     void releaseNote(int noteNumber);
@@ -323,7 +327,17 @@ namespace rosic
     int    currentVel;       // velocity of currently played note
     int    noteOffCountDown; // a countdown variable till next note-off in sequencer mode
     bool   slideToNextNote;  // indicate that we need to slide to the next note in sequencer mode
+    bool   hammerToNextNote; // indicate that we need to hammer (legato w/ instant pitch) to the next note
     bool   idle;             // flag to indicate that we have currently nothing to do in getSample
+    bool   currentNoteMuted; // flag indicating the current note is muted (shorter gate, darker, quieter)
+
+    // TT-303 mute parameters
+    double muteGateFactor;   // gate length multiplier for muted notes (0.4-0.6)
+    double muteLevelFactor;  // VCA level factor for muted notes (0.4-0.7)
+    double muteCutoffFactor; // filter cutoff factor for muted notes (0.6-0.9)
+    double muteEnvFactor;    // envelope mod factor for muted notes (0.6-0.9)
+    double muteMorph;        // smoothed 0..1 muted amount for click-free mute transitions
+    double muteMorphCoeff;   // one-pole coefficient for ~2ms mute smoothing
 
     // LFO modulation depth
     double lfoDepth;    // LFO depth (-1.0 to +1.0)
@@ -358,21 +372,41 @@ namespace rosic
           int key = note->key + 12*note->octave + currentNote;
           key = clip(key, 0, 127);
 
-          if( !slideToNextNote )
-            triggerNote(key, note->accent);
-          else
-            slideToNote(key, note->accent);
+          // Determine accent: mute overrides accent (muted notes are never accented)
+          bool hasAccent = note->accent && !note->mute;
 
+          // Handle note triggering based on previous step's legato state
+          if( !slideToNextNote && !hammerToNextNote )
+            triggerNote(key, hasAccent);
+          else if( hammerToNextNote )
+            hammerToNote(key, hasAccent);  // Instant pitch, no envelope retrigger
+          else
+            slideToNote(key, hasAccent);   // Glide pitch, no envelope retrigger
+
+          // Track if this note is muted (for cutoff/level reduction in audio processing)
+          currentNoteMuted = note->mute;
+
+          // Determine legato behavior for next step transition
           AcidNote* nextNote = sequencer.getNextScheduledNote();
-          if( note->slide && nextNote->gate == true )
+          bool nextHasGate = nextNote->gate == true;
+
+          // slide and hammer both create legato (continuous gate, no env retrigger)
+          // slide = smooth pitch glide, hammer = instant pitch change
+          if( (note->slide || note->hammer) && nextHasGate )
           {
-            noteOffCountDown = INT_MAX;
-            slideToNextNote  = true;
+            noteOffCountDown = INT_MAX;  // Keep gate open
+            slideToNextNote  = note->slide && !note->hammer;  // slide takes precedence only if no hammer
+            hammerToNextNote = note->hammer;
           }
           else
           {
-            noteOffCountDown = sequencer.getStepLengthInSamples();
+            // Calculate gate length - muted notes have shorter gate
+            int gateLength = sequencer.getStepLengthInSamples();
+            if( note->mute )
+              gateLength = (int)(gateLength * muteGateFactor);
+            noteOffCountDown = gateLength;
             slideToNextNote  = false;
+            hammerToNextNote = false;
           }
         }
       }
@@ -423,7 +457,20 @@ namespace rosic
     tmp2 = n2 * rc2.getSample(tmp2);
     tmp1 = envScaler * ( tmp1 - envOffset );  // seems not to work yet
     tmp2 = accentGain*tmp2;
-    double instCutoff = cutoff * pow(2.0, tmp1+tmp2+lfoFilterMod);
+
+    // Smoothly morph the mute reductions (0 = open, 1 = fully muted) so that
+    // level/cutoff/env changes ramp over ~2ms instead of stepping in one sample.
+    // A hard switch on a held (legato hammer/slide) note produces an audible click.
+    double muteTarget = currentNoteMuted ? 1.0 : 0.0;
+    muteMorph = muteTarget + muteMorphCoeff * (muteMorph - muteTarget);
+
+    // Apply mute envelope reduction (morphed)
+    tmp1 *= 1.0 + muteMorph * (muteEnvFactor - 1.0);
+
+    // Apply mute cutoff reduction (morphed, darker tone)
+    double instCutoff = cutoff;
+    instCutoff *= 1.0 + muteMorph * (muteCutoffFactor - 1.0);
+    instCutoff *= pow(2.0, tmp1+tmp2+lfoFilterMod);
     filter.setCutoff(instCutoff);
 
     double ampEnvOut = ampEnv.getSample();
@@ -451,6 +498,9 @@ namespace rosic
     tmp *= ampEnvOut;                       // amplified
     tmp *= ampScaler;
     tmp *= volumeModFactor;                 // LFO volume modulation
+
+    // Apply mute level reduction (morphed, quieter tone)
+    tmp *= 1.0 + muteMorph * (muteLevelFactor - 1.0);
 
     // find out whether we may switch ourselves off for the next call:
     idle = false;


### PR DESCRIPTION
## What

Adds **mute** and **hammer** per-step behaviors to the Open303 DSP engine (`src/dsp/open303`): Engine-only (no GUI/parameter wiring); extends the internal `AcidSequencer`/`AcidNote` model and the `Open303` voice.

## Concepts

Both are new boolean flags on `AcidNote`:

- **mute** — a *choked note* like a palm mute on the guitar, not silence. The step still gates and plays, but weaker and darker. On a muted note four things are scaled:

  | effect | factor |
  |---|---|
  | shorter gate | `muteGateFactor = 0.5` |
  | lower env mod | `muteEnvFactor = 0.7` |
  | darker cutoff | `muteCutoffFactor = 0.7` |
  | quieter VCA | `muteLevelFactor = 0.6` |

  Mute also overrides accent — a muted note is never accented (`accent && !mute`).

- **hammer** — legato like slide (gate stays open, envelope not retriggered) but with an **instant** pitch change instead of portamento, via a new `hammerToNote()` that snaps the pitch slew limiter to the target frequency. When both slide and hammer are set, hammer wins (IMO the GUI shouldn't allow slide and hammer at the same time, see comment below with image of tri-state grids).