### PR TITLE
fix: anti-zipper cutoff smoothing to the Open303 engine

### DIFF
--- a/src/dsp/open303/dfl_DynamicSmoothingFilter.h
+++ b/src/dsp/open303/dfl_DynamicSmoothingFilter.h
@@ -1,0 +1,110 @@
+#ifndef dfl_DynamicSmoothingFilter_h
+#define dfl_DynamicSmoothingFilter_h
+
+#include "GlobalDefinitions.h"
+#include <algorithm>
+#include <cmath>
+
+namespace rosic
+{
+  /**
+   * Dynamic Smoothing Filter using Self Modulating Bandpass
+   * Based on Andrew Simper @ Cytomic - Dynamic Smoothing
+   * https://cytomic.com/files/dsp/DynamicSmoothing.pdf
+   *
+   * This filter adapts its smoothing rate based on the rate of change of the input signal.
+   * Fast changes get more smoothing (to prevent zipper noise), while slow changes pass through
+   * with minimal latency.
+   */
+  class DynamicSmoothingFilter
+  {
+  public:
+    /** Constructor. */
+    DynamicSmoothingFilter()
+    {
+      baseFreq = 2.0;      // Hz - base cutoff frequency for smoothing
+      sensitivity = 2.0;   // sensitivity to rate of change
+      sampleRate = 44100.0;
+      wc = baseFreq / sampleRate;
+      clear();
+    }
+
+    /** Sets the sample rate. */
+    void setSampleRate(double newSampleRate)
+    {
+      sampleRate = newSampleRate;
+      wc = baseFreq / sampleRate;
+    }
+
+    /** Sets the base frequency (in Hz). Lower values = more smoothing. Typical range: 1-10 Hz. */
+    void setBaseFreq(double newBaseFreq)
+    {
+      baseFreq = newBaseFreq;
+      wc = baseFreq / sampleRate;
+    }
+
+    /** Sets the sensitivity to rate of change. Higher values = more aggressive dynamic smoothing.
+     *  Typical range: 1-5. */
+    void setSensitivity(double newSensitivity)
+    {
+      sensitivity = newSensitivity;
+    }
+
+    /** Resets the filter state. */
+    void clear()
+    {
+      low1 = 0.0;
+      low2 = 0.0;
+      inz = 0.0;
+    }
+
+    /** Seeds the filter state so a subsequent getSample() starts at the given value (no glide
+     *  from zero on the first sample after a reset). */
+    void setState(double value)
+    {
+      low1 = value;
+      low2 = value;
+      inz = value;
+    }
+
+    /** Processes one sample through the filter. */
+    INLINE double getSample(double in)
+    {
+      // Store previous states
+      double low1z = low1;
+      double low2z = low2;
+
+      // Calculate bandpass output (difference between two lowpass stages)
+      double bandz = low1z - low2z;
+
+      // Dynamic cutoff based on rate of change
+      double wd = wc + sensitivity * std::abs(bandz);
+
+      // Calculate filter coefficient (polynomial approximation for accurate linear frequency mapping)
+      double g = wd * (5.9948827 + wd * (-11.969296 + wd * 15.959062));
+      g = std::min(g, 1.0);
+
+      // Two-stage cascaded lowpass filter
+      low1 = low1z + g * (0.5 * (in + inz) - low1z);
+      low2 = low2z + g * (0.5 * (low1 + low1z) - low2z);
+
+      // Store input for next iteration
+      inz = in;
+
+      // Output is the second lowpass stage
+      return low2;
+    }
+
+  protected:
+    double baseFreq;     // Base frequency in Hz
+    double sensitivity;  // Sensitivity to rate of change
+    double sampleRate;   // Sample rate in Hz
+    double wc;           // Normalized cutoff frequency
+    double low1;         // First lowpass filter state
+    double low2;         // Second lowpass filter state
+    double inz;          // Previous input sample
+  };
+
+} // namespace rosic
+
+#endif // dfl_DynamicSmoothingFilter_h

--- a/src/dsp/open303/rosic_Open303.cpp
+++ b/src/dsp/open303/rosic_Open303.cpp
@@ -90,6 +90,8 @@ void Open303::setSampleRate(double newSampleRate)
   mainEnv.setSampleRate         (       newSampleRate);
   ampEnv.setSampleRate          (       newSampleRate);
   pitchSlewLimiter.setSampleRate((float)newSampleRate);
+  cutoffSmoother.setSampleRate(         newSampleRate);
+  cutoffSmoother.setState(cutoff);  // seed to current cutoff so we don't sweep up from 0
   ampDeClicker.setSampleRate(    (float)newSampleRate);
   rc1.setSampleRate(             (float)newSampleRate);
   rc2.setSampleRate(             (float)newSampleRate);

--- a/src/dsp/open303/rosic_Open303.h
+++ b/src/dsp/open303/rosic_Open303.h
@@ -12,6 +12,7 @@
 #include "rosic_EllipticQuarterBandFilter.h"
 #include "rosic_AcidSequencer.h"
 #include "dfl_LFO.h"
+#include "dfl_DynamicSmoothingFilter.h"
 
 #include <list>
 
@@ -259,6 +260,7 @@ namespace rosic
     AnalogEnvelope            ampEnv;
     DecayEnvelope             mainEnv;
     LeakyIntegrator           pitchSlewLimiter;
+    DynamicSmoothingFilter    cutoffSmoother;   // anti-zipper smoothing of the cutoff parameter
     //LeakyIntegrator           ampDeClicker;
     BiquadFilter              ampDeClicker;
     LeakyIntegrator           rc1, rc2;
@@ -423,7 +425,9 @@ namespace rosic
     tmp2 = n2 * rc2.getSample(tmp2);
     tmp1 = envScaler * ( tmp1 - envOffset );  // seems not to work yet
     tmp2 = accentGain*tmp2;
-    double instCutoff = cutoff * pow(2.0, tmp1+tmp2+lfoFilterMod);
+    // Anti-zipper: dynamically smooth the (block-rate) cutoff parameter before it drives the filter
+    double smoothedCutoff = cutoffSmoother.getSample(cutoff);
+    double instCutoff = smoothedCutoff * pow(2.0, tmp1+tmp2+lfoFilterMod);
     filter.setCutoff(instCutoff);
 
     double ampEnvOut = ampEnv.getSample();


### PR DESCRIPTION
## What

Adds **anti-zipper smoothing** of the filter cutoff in the Open303 DSP engine (`src/dsp/open303`). The cutoff parameter is updated at block rate (host automation, UI moves, MIDI CC); feeding those discrete steps straight into the ladder filter produces audible zipper noise / stair-stepping. This runs `cutoff` through a per-sample dynamic smoother first.

## How

New `dfl_DynamicSmoothingFilter.h` — a Cytomic-style **self-modulating dynamic smoothing** filter (Andrew Simper, https://cytomic.com/files/dsp/DynamicSmoothing.pdf). It adapts its own smoothing rate to the input's rate of change:

- fast jumps → more smoothing (kills the zipper)
- slow moves → pass through with minimal latency

Defaults: base frequency 2 Hz, sensitivity 2.

In `Open303::getSample`, the raw `cutoff` is smoothed before the envelope/accent/LFO exponent is applied:

```cpp
double smoothedCutoff = cutoffSmoother.getSample(cutoff);
double instCutoff = smoothedCutoff * pow(2.0, tmp1+tmp2+lfoFilterMod);
```

`setSampleRate` registers the smoother's sample rate and **seeds its state to the current cutoff**, so there's no filter sweep up from zero on startup / after a sample-rate change.
