### PR TITLE
fix fidelity: portamento in log-frequency (V/oct) instead of Hz

### DIFF
--- a/src/dsp/open303/rosic_Open303.cpp
+++ b/src/dsp/open303/rosic_Open303.cpp
@@ -129,7 +129,19 @@ void Open303::setSlideTime(double newSlideTime)
   if( newSlideTime >= 0.0 )
   {
     slideTime = newSlideTime;
-    pitchSlewLimiter.setTimeConstant((float)(0.2*slideTime));  // \todo: tweak the scaling constant
+    // The TB-303 slide is a passive RC lag on the pitch DAC output: the DAC feeds C = 0.22 uF
+    // through R = 100 kOhm (stock) up to ~603 kOhm (with the Devil Fish slide pot), so the RC time
+    // constant tau = R*C runs from ~22 ms stock to ~133 ms at maximum (~6x). Because the pitch CV is
+    // volts/octave, this lag acts in the log-frequency domain (see getSample / triggerNote), which
+    // is why the glide is even in pitch and takes the same time regardless of interval.
+    //
+    // slideTime is the full slide time in ms; the stock 303 is ~60 ms, which corresponds to the
+    // ~22 ms RC constant (about 3 tau to settle). tau = slideTime * (22/60) keeps the digital
+    // one-pole matched to the hardware RC across the whole range, so the Devil Fish "Slide Time" mod
+    // knob (which drives this via setParameter, mapping its 0..1 to ~2..360 ms) sweeps tau from
+    // ~0.7 ms (near-instant) through 22 ms at the 60 ms stock point up to ~133 ms - i.e. the knob's
+    // top lands exactly on the real hardware maximum.
+    pitchSlewLimiter.setTimeConstant((float)(slideTime * (22.0/60.0)));
   }
 }
 
@@ -239,7 +251,9 @@ void Open303::triggerNote(int noteNumber, bool hasAccent)
   }
 
   oscFreq = pitchToFreq(noteNumber, tuning);
-  pitchSlewLimiter.setState(oscFreq);
+  // Seed the slew limiter in the log-frequency domain (it glides log(freq), see getSample), so a
+  // freshly triggered note starts exactly on pitch with no glide.
+  pitchSlewLimiter.setState(log(oscFreq));
   mainEnv.trigger();
   ampEnv.noteOn(true, noteNumber, 64);
   idle = false;

--- a/src/dsp/open303/rosic_Open303.h
+++ b/src/dsp/open303/rosic_Open303.h
@@ -357,8 +357,11 @@ namespace rosic
       }
     }
 
-    // calculate instantaneous oscillator frequency and set up the oscillator:
-    double instFreq = pitchSlewLimiter.getSample(oscFreq);
+    // calculate instantaneous oscillator frequency and set up the oscillator. The portamento slew
+    // runs in the log-frequency domain (glide log(freq), then exponentiate back to Hz) so the slide
+    // is linear in pitch/cents rather than in Hz - this matches how a real 303 slews its pitch CV
+    // (volts/octave) and keeps octave slides from lingering in the low end.
+    double instFreq = exp( pitchSlewLimiter.getSample( log(oscFreq) ) );
     oscillator.setFrequency(instFreq*pitchWheelFactor);
     oscillator.calculateIncrement();
 


### PR DESCRIPTION
## Slide/glide: authentic TB-303 portamento (log-frequency domain + RC-calibrated time)

Two related fixes making the portamento match the real TB-303 slide circuit — a passive RC lag on the **1 V/octave pitch CV** (the pitch-DAC output fed through R into C = 0.22 µF).

### 1. Glide in log-frequency (V/oct), not Hz
Because the slewed node is the 1 V/oct CV, the slide happens in the **log-frequency** domain. The emulation was slewing raw **Hz**, so octave+ slides front-loaded the pitch (raced up in cents early, then crawled).
- `getSample()`: run the `LeakyIntegrator` slew on `log(oscFreq)`, then `exp()` back to Hz → glide linear in cents regardless of interval.
- `triggerNote()`: seed the slew state with `log(oscFreq)` so a fresh note starts exactly on pitch.

Before/after, 2-octave C2→C4 slide (semitones of 24 covered):

| t (ms) | before (Hz-domain) | after (log-domain) |
|--------|--------------------|--------------------|
| 60  | 18.3 | 15.5 |
| 100 | 20.7 | 18.4 |
| 140 | 22.1 | 20.6 |

Even in pitch after; both land on target; max sample jump identical → no new clicks.

### 2. Calibrate the glide time constant to the real RC
The one-pole τ was a fudge (`0.2·slideTime`, marked `\todo: tweak`). The 303 RC is **R·C** with C = 0.22 µF and R = 100 kΩ stock → **τ ≈ 22 ms**, up to ~603 kΩ with the Devil Fish slide pot → **τ ≈ 133 ms** (~6×). The stock ~60 ms slide is that 22 ms constant (~3τ to settle), so:

```
tau = slideTime * (22/60)
```

matches the digital one-pole to the hardware across the whole range. This also lines up the **"Slide Time" mod knob** (`setParameter` maps its 0..1 → ~2..360 ms): τ sweeps ~0.7 ms → **22 ms at the 60 ms stock point** → **~133 ms**, so the knob's top lands exactly on the real hardware maximum.

Validated with a standalone octave-glide render:

| slide setting | expected τ | measured τ (63% crossing) | ~95% by |
|---------------|-----------|----------------------------|---------|
| 60 ms (stock) | 22 ms  | ~20 ms  | ~60 ms |
| 360 ms (max)  | 132 ms | ~120 ms | ~360 ms |

dipstik PASS (no clip, no DC, level unchanged). Only touches `src/dsp/open303/rosic_Open303.{h,cpp}`.

Circuit reference (RC lag on the 1 V/oct pitch CV): [Emulating TB-303 slide — Gearspace](https://gearspace.com/board/electronic-music-instruments-and-electronic-music-production/1216976-emulating-tb-303-slide.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sc2Taik4G6PGmg5bYnSU5A
