### PR TITLE
fix: cleanup param-update race, GUI leaks, dead code (stacked on #43)

### DIFF
--- a/src/JC303.cpp
+++ b/src/JC303.cpp
@@ -63,6 +63,11 @@ JC303::JC303()
                                                         0.0f,
                                                         1.0f,
                                                         0.03f),
+            std::make_unique<juce::AudioParameterFloat> ("accentSoftAttack",
+                                                        "Accent Soft Attack",
+                                                        0.0f,
+                                                        1.0f,
+                                                        0.6f),   // ~15 ms base, the original 303 value
             std::make_unique<juce::AudioParameterFloat> ("feedbackFilter",
                                                         "Filt. FeedBack",
                                                         0.0f,
@@ -120,6 +125,7 @@ JC303::JC303()
     switchModState = parameters.getRawParameterValue("switchModState");
     normalDecay = parameters.getRawParameterValue("normalDecay");
     accentDecay = parameters.getRawParameterValue("accentDecay");
+    accentSoftAttack = parameters.getRawParameterValue("accentSoftAttack");
     feedbackFilter = parameters.getRawParameterValue("feedbackFilter");
     softAttack = parameters.getRawParameterValue("softAttack");
     slideTime = parameters.getRawParameterValue("slideTime");
@@ -142,6 +148,7 @@ JC303::JC303()
     setDevilMod(*switchModState);
     setParameter(NORMAL_DECAY, *normalDecay);
     setParameter(ACCENT_DECAY, *accentDecay);
+    setParameter(ACCENT_SOFT_ATTACK, *accentSoftAttack);
     setParameter(FEEDBACK_HPF, *feedbackFilter);
     setParameter(SOFT_ATTACK, *softAttack);
     setParameter(SLIDE_TIME, *slideTime);
@@ -171,6 +178,7 @@ JC303::JC303()
     parameters.addParameterListener("volume", this);
     parameters.addParameterListener("normalDecay", this);
     parameters.addParameterListener("accentDecay", this);
+    parameters.addParameterListener("accentSoftAttack", this);
     parameters.addParameterListener("feedbackFilter", this);
     parameters.addParameterListener("softAttack", this);
     parameters.addParameterListener("slideTime", this);
@@ -194,6 +202,7 @@ JC303::~JC303()
     parameters.removeParameterListener("volume", this);
     parameters.removeParameterListener("normalDecay", this);
     parameters.removeParameterListener("accentDecay", this);
+    parameters.removeParameterListener("accentSoftAttack", this);
     parameters.removeParameterListener("feedbackFilter", this);
     parameters.removeParameterListener("softAttack", this);
     parameters.removeParameterListener("slideTime", this);
@@ -241,6 +250,9 @@ void JC303::parameterChanged(const juce::String& parameterID, float newValue)
     }
     else if (parameterID == "accentDecay" && *switchModState) {
         setParameter(ACCENT_DECAY, newValue);
+    }
+    else if (parameterID == "accentSoftAttack" && *switchModState) {
+        setParameter(ACCENT_SOFT_ATTACK, newValue);
     }
     else if (parameterID == "feedbackFilter" && *switchModState) {
         setParameter(FEEDBACK_HPF, newValue);
@@ -349,6 +361,16 @@ void JC303::setParameter (Open303Parameters index, float value)
             linToLin(value, 0.0, 1.0, 30.0,      3000.0)
         );
         break;
+    case ACCENT_SOFT_ATTACK:
+        /*
+        Base time for the accent "capacitor" discharge (1..100 ms). Resonance
+        scales this 1x..3x, so effective range is ~1..300 ms. Low = sharp/direct
+        (Devil Fish style), high = slow/accumulative TB-303 accent sweeps.
+        */
+        open303Core.setAccentAttack(
+            linToExp(value, 0.0, 1.0,  1.0,    100.0)
+        );
+        break;
     case FEEDBACK_HPF:
         // this one is expresive only on higher reesonances
         open303Core.setFeedbackHighpass(
@@ -398,6 +420,7 @@ void JC303::setDevilMod(bool mode)
         decayMax = 3000.0;
         setParameter(NORMAL_DECAY, *normalDecay);
         setParameter(ACCENT_DECAY, *accentDecay);
+    setParameter(ACCENT_SOFT_ATTACK, *accentSoftAttack);
         setParameter(FEEDBACK_HPF, *feedbackFilter);
         setParameter(SOFT_ATTACK, *softAttack);
         setParameter(SLIDE_TIME, *slideTime);
@@ -422,7 +445,10 @@ void JC303::setDevilMod(bool mode)
         //open303Core.setAmpSustain(-6.02); // dB2amp(newSustain) = 0.5 ~ -6.0205 or -8.68589?
         //open303Core.setAmpRelease(1.0); // 1.0
         // fixed parameters restore
-        ////open303Core.setAccentAttack(3.0); // 3.0?
+        // stock accent capacitor: 15 ms, the original Open303 value (the Accent
+        // Soft Attack mod knob only applies in devilfish mode). Resonance still
+        // scales this in setResonance, as on the real 303.
+        open303Core.setAccentAttack(15.0);
     }
 }
 

--- a/src/JC303.cpp
+++ b/src/JC303.cpp
@@ -214,67 +214,42 @@ JC303::~JC303()
     parameters.removeParameterListener("switchOverdriveState", this);
 }
 
-// Parameter change callback
+// Parameter change callback. Runs on the message/automation thread, NOT the audio thread, so it may
+// only touch cheap flags here - the actual open303 setters (which rewrite filter/envelope
+// coefficients the audio thread reads inside getSample) are deferred to updateOpen303Parameters(),
+// applied at the top of processBlock. This closes the torn-read race Fable flagged.
 void JC303::parameterChanged(const juce::String& parameterID, float newValue)
 {
-    // Map parameter ID to enum and update immediately or set flag
-    if (parameterID == "waveform") {
-        setParameter(WAVEFORM, newValue);
-    }
-    else if (parameterID == "tuning") {
-        setParameter(TUNING, newValue);
-    }
-    else if (parameterID == "cutoff") {
-        setParameter(CUTOFF, newValue);
-    }
-    else if (parameterID == "resonance") {
-        setParameter(RESONANCE, newValue);
-    }
-    else if (parameterID == "envmod") {
-        setParameter(ENVMOD, newValue);
-    }
-    else if (parameterID == "decay") {
-        setParameter(DECAY, newValue);
-    }
-    else if (parameterID == "accent") {
-        setParameter(ACCENT, newValue);
-    }
-    else if (parameterID == "volume") {
-        setParameter(VOLUME, newValue);
-    }
-    else if (parameterID == "switchModState") {
-        setDevilMod(newValue > 0.5f);
-    }
-    else if (parameterID == "normalDecay" && *switchModState) {
-        setParameter(NORMAL_DECAY, newValue);
-    }
-    else if (parameterID == "accentDecay" && *switchModState) {
-        setParameter(ACCENT_DECAY, newValue);
-    }
-    else if (parameterID == "accentSoftAttack" && *switchModState) {
-        setParameter(ACCENT_SOFT_ATTACK, newValue);
-    }
-    else if (parameterID == "feedbackFilter" && *switchModState) {
-        setParameter(FEEDBACK_HPF, newValue);
-    }
-    else if (parameterID == "softAttack" && *switchModState) {
-        setParameter(SOFT_ATTACK, newValue);
-    }
-    else if (parameterID == "slideTime" && *switchModState) {
-        setParameter(SLIDE_TIME, newValue);
-    }
-    else if (parameterID == "sqrDriver" && *switchModState) {
-        setParameter(TANH_SHAPER_DRIVE, newValue);
-    }
-    else if (parameterID == "overdriveLevel") {
-        setParameter(OVERDRIVE_LEVEL, newValue);
-    }
-    else if (parameterID == "overdriveDryWet") {
-        setParameter(OVERDRIVE_DRY_WET, newValue);
-    }
-    else if (parameterID == "overdriveModelIndex") {
+    // Exception: loading an overdrive model allocates and touches the filesystem, which must happen
+    // off the audio thread. Keep it here on the message thread rather than deferring it.
+    if (parameterID == "overdriveModelIndex") {
         setParameter(OVERDRIVE_MODEL_INDEX, newValue);
+        return;
     }
+
+    // Everything else (waveform, tuning, cutoff, resonance, envmod, decay, accent, volume, the devil
+    // mod toggle + its pots, and overdrive level/mix) maps to cheap DSP setters. Flag them so the
+    // audio thread re-applies the current APVTS values in updateOpen303Parameters().
+    parametersNeedUpdate.store(true);
+}
+
+// Applies every cheap DSP parameter from the current APVTS atomic values. Audio-thread only.
+void JC303::updateOpen303Parameters()
+{
+    setParameter(WAVEFORM, *waveForm);
+    setParameter(TUNING, *tuning);
+    setParameter(CUTOFF, *cutoffFreq);
+    setParameter(RESONANCE, *resonance);
+    setParameter(ENVMOD, *envelopMod);
+    setParameter(ACCENT, *accent);
+    setParameter(VOLUME, *volume);
+    // setDevilMod adjusts decayMin/decayMax and (re)applies the mod pots (or restores fixed 303
+    // values), so it must run before DECAY, which reads that range.
+    setDevilMod(*switchModState > 0.5f);
+    setParameter(DECAY, *decay);
+    // Overdrive gain/mix are cheap; the model index is loaded on the message thread (see above).
+    setParameter(OVERDRIVE_LEVEL, *overdriveLevel);
+    setParameter(OVERDRIVE_DRY_WET, *overdriveDryWet);
 }
 
 void JC303::setParameter (Open303Parameters index, float value)
@@ -346,10 +321,14 @@ void JC303::setParameter (Open303Parameters index, float value)
     //
     case NORMAL_DECAY:
         /*
-        On non-accented notes, the TB-303’s Main Envelope Generator (MEG) had a decay time
-        between 200 ms and 2 seconds – as controlled by the Decay pot. On accented notes, the
-        decay time was fixed to 200 ms. In the Devil Fish, there are two new pots for MEG decay –
-        Normal Decay and Accent Decay. Both have a range between 30 ms and 3 seconds.
+        Background (Devil Fish): on non-accented notes the TB-303's Main Envelope Generator (MEG) had
+        a decay time between 200 ms and 2 s (the Decay pot); on accented notes it was fixed to 200 ms.
+        The Devil Fish adds Normal Decay and Accent Decay pots, each 30 ms - 3 s.
+
+        NOTE: unlike the Devil Fish "Normal Decay" (which retimes the MEG / filter envelope), this
+        control drives the *amplitude* envelope decay via setAmpDecay(). The MEG decay is still set by
+        the main DECAY parameter. Kept as-is to preserve the current voicing; treat the name as
+        "normal (amp) decay" rather than a literal Devil Fish MEG-decay clone.
         */
         open303Core.setAmpDecay(
             linToLin(value, 0.0, 1.0, 30.0,      3000.0)
@@ -574,7 +553,12 @@ void JC303::processBlock (juce::AudioBuffer<float>& buffer,
     juce::ScopedNoDenormals noDenormals;
     auto currentSample = 0;
     const auto numSamples = buffer.getNumSamples();
-    
+
+    // Apply any pending parameter changes here on the audio thread, before rendering, so open303's
+    // coefficients are never rewritten concurrently with getSample() reading them.
+    if (parametersNeedUpdate.exchange(false))
+        updateOpen303Parameters();
+
     // clear buffer
     auto totalNumInputChannels  = getTotalNumInputChannels();
     auto totalNumOutputChannels = getTotalNumOutputChannels();

--- a/src/JC303.h
+++ b/src/JC303.h
@@ -23,6 +23,7 @@ enum Open303Parameters
   SWITCH_MOD,
   NORMAL_DECAY,
   ACCENT_DECAY,
+  ACCENT_SOFT_ATTACK,
   FEEDBACK_HPF,
   SOFT_ATTACK,
   SLIDE_TIME,
@@ -118,6 +119,7 @@ private:
     std::atomic<float>* switchModState = nullptr;
     std::atomic<float>* normalDecay = nullptr;
     std::atomic<float>* accentDecay = nullptr;
+    std::atomic<float>* accentSoftAttack = nullptr;
     std::atomic<float>* feedbackFilter = nullptr;
     std::atomic<float>* softAttack = nullptr;
     std::atomic<float>* slideTime = nullptr;

--- a/src/JC303.h
+++ b/src/JC303.h
@@ -88,6 +88,9 @@ public:
 private:
     void render303(juce::AudioBuffer<float>& buffer, int beginSample, int endSample);
     void setParameter (Open303Parameters index, float value);
+    // Re-applies all cheap DSP parameters from the APVTS atomics on the audio thread. Called from
+    // processBlock when parametersNeedUpdate is set, so parameter writes never race getSample().
+    void updateOpen303Parameters();
 
     // presets and overdrive models user data management
     void setupDataDirectories();

--- a/src/dsp/open303/rosic_Open303.cpp
+++ b/src/dsp/open303/rosic_Open303.cpp
@@ -333,7 +333,13 @@ void Open303::updateNormalizer1()
 
 void Open303::updateNormalizer2()
 {
+  // Intentionally leave the accent capacitor (rc2) un-normalized. getNormalizer
+  // would rescale rc2's output to hold the accent's peak level constant as its
+  // time constant changes, decoupling level from timing. We keep n2 = 1.0 so a
+  // slower discharge (higher Accent Soft Attack / resonance) also lowers the
+  // per-note accent level - modelling a real analog cap that reaches a lower
+  // voltage when it charges more slowly.
   n2 = LeakyIntegrator::getNormalizer(mainEnv.getDecayTimeConstant(), rc2.getTimeConstant(),
     sampleRate);
-  n2 = 1.0; // test
+  n2 = 1.0;
 }

--- a/src/dsp/open303/rosic_Open303.cpp
+++ b/src/dsp/open303/rosic_Open303.cpp
@@ -18,6 +18,7 @@ Open303::Open303()
   envUpFraction    =     2.0/3.0;
   normalAttack     =     3.0;
   accentAttack     =     3.0;
+  resonanceSkewed  =     0.0;
   normalDecay      =  1000.0;
   accentDecay      =   200.0;
   normalAmpRelease =     1.0;

--- a/src/dsp/open303/rosic_Open303.cpp
+++ b/src/dsp/open303/rosic_Open303.cpp
@@ -326,9 +326,11 @@ void Open303::calculateEnvModScalerAndOffset()
 
 void Open303::updateNormalizer1()
 {
-  n1 = LeakyIntegrator::getNormalizer(mainEnv.getDecayTimeConstant(), rc1.getTimeConstant(),
-    sampleRate);
-  n1 = 1.0; // test
+  // Normalization intentionally disabled: the leaky integrator rc1 runs unnormalized (n1 = 1) to
+  // preserve the envelope depth this emulation was voiced against. The analytic
+  // LeakyIntegrator::getNormalizer() compensation was previously computed here and then immediately
+  // overwritten (the "// test" line), i.e. dead - so the call has been removed.
+  n1 = 1.0;
 }
 
 void Open303::updateNormalizer2()

--- a/src/dsp/open303/rosic_Open303.h
+++ b/src/dsp/open303/rosic_Open303.h
@@ -56,7 +56,16 @@ namespace rosic
     void setCutoff(double newCutoff); 
 
     /** Sets the resonance amount for the filter. */
-    void setResonance(double newResonance) { filter.setResonance(newResonance); }
+    void setResonance(double newResonance)
+    {
+      filter.setResonance(newResonance);
+
+      // TB-303 accent capacitor: the resonance pot controls the accent-sweep
+      // circuit's discharge rate. Higher resonance = slower discharge = the accent
+      // sweeps up more smoothly and stacks higher on rapid successive accents.
+      resonanceSkewed = (1.0 - exp(-3.0 * 0.01 * newResonance)) / (1.0 - exp(-3.0));
+      rc2.setTimeConstant(accentAttack * (1.0 + resonanceSkewed * 2.0));
+    }
 
     /** Sets the modulation depth of the filter's cutoff frequency by the filter-envelope generator 
     (in percent). */
@@ -116,10 +125,12 @@ namespace rosic
 
     /** Sets the filter envelope's attack time for accented notes (in milliseconds). In the 
     Devil Fish, accented notes have a fixed attack time of 3 ms.  */
-    void setAccentAttack(double newAccentAttack) 
-    { 
-      accentAttack = newAccentAttack; 
-      rc2.setTimeConstant(accentAttack);
+    void setAccentAttack(double newAccentAttack)
+    {
+      accentAttack = newAccentAttack;
+      // The resonance pot scales the accent capacitor's discharge lag (see
+      // setResonance): tau = accentAttack * (1 + 2*resonance), so 1x..3x.
+      rc2.setTimeConstant(accentAttack * (1.0 + resonanceSkewed * 2.0));
     }
 
     /** Sets the filter envelope's decay time for accented notes (in milliseconds). 
@@ -295,6 +306,7 @@ namespace rosic
     double envScaler;        // scale-factor for the normalized envelope (derived from envMod)
     double normalAttack;     // attack time for the filter envelope on non-accented notes
     double accentAttack;     // attack time for the filter envelope on accented notes
+    double resonanceSkewed;  // skewed resonance (0-1), scales the accent capacitor lag
     double normalDecay;      // decay time for the filter envelope on non-accented notes
     double accentDecay;      // decay time for the filter envelope on accented notes
     double normalAmpRelease; // amp-env release time for non-accented notes

--- a/src/dsp/open303/rosic_Open303.h
+++ b/src/dsp/open303/rosic_Open303.h
@@ -329,8 +329,10 @@ namespace rosic
 
   INLINE double Open303::getSample()
   {
-    //if( sequencer.getSequencerMode() == AcidSequencer::OFF && ampEnv.endIsReached() )
-    //  return 0.0;
+    // 'idle' short-circuits output before the first note is ever triggered (it starts true and is
+    // cleared on the first trigger). Note it is never set back to true afterwards, so this is only a
+    // pre-first-note guard; re-enabling end-of-note detection here to save CPU on silence is a
+    // possible future optimization but needs click-free retrigger testing.
     if( idle )
       return 0.0;
 
@@ -382,7 +384,7 @@ namespace rosic
     if( accentGain > 0.0 )
       tmp2 = mainEnvOut;
     tmp2 = n2 * rc2.getSample(tmp2);  
-    tmp1 = envScaler * ( tmp1 - envOffset );  // seems not to work yet
+    tmp1 = envScaler * ( tmp1 - envOffset );  // main env-mod scaling (Schmidt's measured mapping)
     tmp2 = accentGain*tmp2;
     double instCutoff = cutoff * pow(2.0, tmp1+tmp2);
     filter.setCutoff(instCutoff);
@@ -411,11 +413,6 @@ namespace rosic
     tmp  = notch.getSample(tmp);
     tmp *= ampEnvOut;                       // amplified
     tmp *= ampScaler;
-
-    // find out whether we may switch ourselves off for the next call:
-    idle = false;
-    //idle = (sequencer.getSequencerMode() == AcidSequencer::OFF && ampEnv.endIsReached() 
-    //        && fabs(tmp) < 0.000001); // ampEnvOut < 0.000001;
 
     return tmp;
   }

--- a/src/gui/amadeusp/Gui.cpp
+++ b/src/gui/amadeusp/Gui.cpp
@@ -18,6 +18,7 @@ JC303Editor::JC303Editor (JC303& p, juce::AudioProcessorValueTreeState& vts)
     addAndMakeVisible(accentDecaySlider = createKnob("small"));
     addAndMakeVisible(feedbackFilterSlider = createKnob("small"));
     addAndMakeVisible(softAttackSlider = createKnob("small"));
+    addAndMakeVisible(accentSoftAttackSlider = createKnob("small"));
     addAndMakeVisible(slideTimeSlider = createKnob("small"));
     addAndMakeVisible(sqrDriverSlider = createKnob("small"));
     // on/off mod switch
@@ -49,6 +50,7 @@ JC303Editor::JC303Editor (JC303& p, juce::AudioProcessorValueTreeState& vts)
     accentDecayAttachment.reset(new SliderAttachment(valueTreeState, "accentDecay", *accentDecaySlider));
     feedbackFilterAttachment.reset(new SliderAttachment(valueTreeState, "feedbackFilter", *feedbackFilterSlider));
     softAttackAttachment.reset(new SliderAttachment(valueTreeState, "softAttack", *softAttackSlider));
+    accentSoftAttackAttachment.reset(new SliderAttachment(valueTreeState, "accentSoftAttack", *accentSoftAttackSlider));
     slideTimeAttachment.reset(new SliderAttachment(valueTreeState, "slideTime", *slideTimeSlider));
     sqrDriverAttachment.reset(new SliderAttachment(valueTreeState, "sqrDriver", *sqrDriverSlider));
     switchModButtonAttachment.reset(new ButtonAttachment(valueTreeState, "switchModState", *switchModButton));
@@ -161,6 +163,9 @@ void JC303Editor::setControlsLayout()
     pair<int, int> softAttackLocation = {330, 273};
     pair<int, int> slideTimeLocation = {391, 273};
     pair<int, int> sqrDriverLocation = {452, 273};
+    // placeholder position directly below the Soft Attack knob (x=330); the
+    // amadeusp background art has no label here yet
+    pair<int, int> accentSoftAttackLocation = {330, 310};
     // MODs switch
     pair<int, int> switchLocation = {52, 273};
     pair<int, int> modLedLocation = {82, 243};
@@ -190,6 +195,7 @@ void JC303Editor::setControlsLayout()
     accentDecaySlider->setBounds(accentDecayLocation.first, accentDecayLocation.second, sliderSmallSize, sliderSmallSize);
     feedbackFilterSlider->setBounds(feedbackFilterLocation.first, feedbackFilterLocation.second, sliderSmallSize, sliderSmallSize);
     softAttackSlider->setBounds(softAttackLocation.first, softAttackLocation.second, sliderSmallSize, sliderSmallSize);
+    accentSoftAttackSlider->setBounds(accentSoftAttackLocation.first, accentSoftAttackLocation.second, sliderSmallSize, sliderSmallSize);
     slideTimeSlider->setBounds(slideTimeLocation.first, slideTimeLocation.second, sliderSmallSize, sliderSmallSize);
     sqrDriverSlider->setBounds(sqrDriverLocation.first, sqrDriverLocation.second, sliderSmallSize, sliderSmallSize);
     switchModButton->setBounds(switchLocation.first, switchLocation.second, switchWidth, switchHeight);

--- a/src/gui/amadeusp/Gui.cpp
+++ b/src/gui/amadeusp/Gui.cpp
@@ -5,33 +5,34 @@ JC303Editor::JC303Editor (JC303& p, juce::AudioProcessorValueTreeState& vts)
     : AudioProcessorEditor (&p), processorRef (p), valueTreeState (vts)
 {
     // Create and configure rotary sliders for each parameter
-    addAndMakeVisible(waveformSlider = createKnob("large"));
-    addAndMakeVisible(volumeSlider = createKnob("large"));
-    addAndMakeVisible(tuningSlider = createKnob("medium"));
-    addAndMakeVisible(cutoffFreqSlider = createKnob("medium"));
-    addAndMakeVisible(resonanceSlider = createKnob("medium"));
-    addAndMakeVisible(envelopModSlider = createKnob("medium"));
-    addAndMakeVisible(decaySlider = createKnob("medium"));
-    addAndMakeVisible(accentSlider = createKnob("medium"));
+    addAndMakeVisible(*(waveformSlider = createKnob("large")));
+    addAndMakeVisible(*(volumeSlider = createKnob("large")));
+    addAndMakeVisible(*(tuningSlider = createKnob("medium")));
+    addAndMakeVisible(*(cutoffFreqSlider = createKnob("medium")));
+    addAndMakeVisible(*(resonanceSlider = createKnob("medium")));
+    addAndMakeVisible(*(envelopModSlider = createKnob("medium")));
+    addAndMakeVisible(*(decaySlider = createKnob("medium")));
+    addAndMakeVisible(*(accentSlider = createKnob("medium")));
     // MODs row
-    addAndMakeVisible(normalDecaySlider = createKnob("small"));
-    addAndMakeVisible(accentDecaySlider = createKnob("small"));
-    addAndMakeVisible(feedbackFilterSlider = createKnob("small"));
-    addAndMakeVisible(softAttackSlider = createKnob("small"));
-    addAndMakeVisible(accentSoftAttackSlider = createKnob("small"));
-    addAndMakeVisible(slideTimeSlider = createKnob("small"));
-    addAndMakeVisible(sqrDriverSlider = createKnob("small"));
+    addAndMakeVisible(*(normalDecaySlider = createKnob("small")));
+    addAndMakeVisible(*(accentDecaySlider = createKnob("small")));
+    addAndMakeVisible(*(feedbackFilterSlider = createKnob("small")));
+    addAndMakeVisible(*(softAttackSlider = createKnob("small")));
+    addAndMakeVisible(*(accentSoftAttackSlider = createKnob("small")));
+    addAndMakeVisible(*(slideTimeSlider = createKnob("small")));
+    addAndMakeVisible(*(sqrDriverSlider = createKnob("small")));
     // on/off mod switch
-    addAndMakeVisible(switchModButton = createSwitch());
-    addAndMakeVisible(ledModButton = createLed("switchModState"));
+    addAndMakeVisible(*(switchModButton = createSwitch()));
+    addAndMakeVisible(*(ledModButton = createLed("switchModState")));
     // overdrive
-    addAndMakeVisible(overdriveLevelSlider = createKnob("small"));
-    addAndMakeVisible(overdriveDryWetSlider = createKnob("small"));
+    addAndMakeVisible(*(overdriveLevelSlider = createKnob("small")));
+    addAndMakeVisible(*(overdriveDryWetSlider = createKnob("small")));
     // on/off overdrive switch
-    addAndMakeVisible(switchOverdriveButton = createSwitch());
-    addAndMakeVisible(ledOverdriveButton = createLed("switchOverdriveState"));
+    addAndMakeVisible(*(switchOverdriveButton = createSwitch()));
+    addAndMakeVisible(*(ledOverdriveButton = createLed("switchOverdriveState")));
     // overdrive model select component
-    addAndMakeVisible(overdriveModelSelect = new OverdriveModelSelect(valueTreeState, processorRef.getModelListNames()));
+    overdriveModelSelect = std::make_unique<OverdriveModelSelect>(valueTreeState, processorRef.getModelListNames());
+    addAndMakeVisible(*overdriveModelSelect);
 
     // Easter egg mr. smile
     addAndMakeVisible(acidSmile);
@@ -68,6 +69,19 @@ JC303Editor::JC303Editor (JC303& p, juce::AudioProcessorValueTreeState& vts)
 
 JC303Editor::~JC303Editor()
 {
+    // Detach each knob from its KnobLookAndFeel before the look-and-feel members are destroyed, so no
+    // slider is left holding a dangling look-and-feel pointer during teardown.
+    for (juce::Slider* s : { waveformSlider.get(), tuningSlider.get(), cutoffFreqSlider.get(),
+                             resonanceSlider.get(), envelopModSlider.get(), decaySlider.get(),
+                             accentSlider.get(), volumeSlider.get(), normalDecaySlider.get(),
+                             accentDecaySlider.get(), feedbackFilterSlider.get(), softAttackSlider.get(),
+                             accentSoftAttackSlider.get(),
+                             slideTimeSlider.get(), sqrDriverSlider.get(), overdriveLevelSlider.get(),
+                             overdriveDryWetSlider.get() })
+    {
+        if (s != nullptr)
+            s->setLookAndFeel(nullptr);
+    }
 }
 
 //==============================================================================
@@ -92,9 +106,9 @@ void JC303Editor::resized()
     setControlsLayout();
 }
 
-juce::Slider* JC303Editor::createKnob(const juce::String& knobType)
+std::unique_ptr<juce::Slider> JC303Editor::createKnob(const juce::String& knobType)
 {
-    auto* slider = new juce::Slider();
+    auto slider = std::make_unique<juce::Slider>();
     slider->setSliderStyle(juce::Slider::RotaryHorizontalVerticalDrag);
     if (knobType == "small")
     {
@@ -108,7 +122,7 @@ juce::Slider* JC303Editor::createKnob(const juce::String& knobType)
     {
         slider->setLookAndFeel(&largeKnobLookAndFeel);
     }
-    
+
     slider->setTextBoxStyle(juce::Slider::TextEntryBoxPosition::NoTextBox, true, 0, 0);
 
     // adjust our start and end point for knob
@@ -116,18 +130,17 @@ juce::Slider* JC303Editor::createKnob(const juce::String& knobType)
     return slider;
 }
 
-SwitchButton* JC303Editor::createSwitch()
+std::unique_ptr<SwitchButton> JC303Editor::createSwitch()
 {
-    auto* button = new SwitchButton();
+    auto button = std::make_unique<SwitchButton>();
     button->setClickingTogglesState(false);
 
     return button;
 }
 
-SwitchLed* JC303Editor::createLed(const juce::String& paramID)
+std::unique_ptr<SwitchLed> JC303Editor::createLed(const juce::String& paramID)
 {
-    auto* led = new SwitchLed(valueTreeState, paramID);
-    return led;
+    return std::make_unique<SwitchLed>(valueTreeState, paramID);
 }
 
 void JC303Editor::setControlsLayout()

--- a/src/gui/amadeusp/Gui.h
+++ b/src/gui/amadeusp/Gui.h
@@ -46,6 +46,7 @@ private:
     juce::Slider* accentDecaySlider;
     juce::Slider* feedbackFilterSlider;
     juce::Slider* softAttackSlider;
+    juce::Slider* accentSoftAttackSlider;
     juce::Slider* slideTimeSlider;
     juce::Slider* sqrDriverSlider;
     SwitchButton* switchModButton;
@@ -70,6 +71,7 @@ private:
     std::unique_ptr<SliderAttachment> accentDecayAttachment;
     std::unique_ptr<SliderAttachment> feedbackFilterAttachment;
     std::unique_ptr<SliderAttachment> softAttackAttachment;
+    std::unique_ptr<SliderAttachment> accentSoftAttackAttachment;
     std::unique_ptr<SliderAttachment> slideTimeAttachment;
     std::unique_ptr<SliderAttachment> sqrDriverAttachment;
     std::unique_ptr<ButtonAttachment> switchModButtonAttachment;

--- a/src/gui/amadeusp/Gui.h
+++ b/src/gui/amadeusp/Gui.h
@@ -23,9 +23,9 @@ public:
     void resized() override;
 
 private:
-    juce::Slider* createKnob(const juce::String& knobType);
-    SwitchButton* createSwitch();
-    SwitchLed* createLed(const juce::String& paramID);
+    std::unique_ptr<juce::Slider> createKnob(const juce::String& knobType);
+    std::unique_ptr<SwitchButton> createSwitch();
+    std::unique_ptr<SwitchLed> createLed(const juce::String& paramID);
     void setControlsLayout();
 
     // This reference is provided as a quick way for your editor to
@@ -33,29 +33,29 @@ private:
     JC303& processorRef;
 
     // Main slider controls
-    juce::Slider* waveformSlider;
-    juce::Slider* tuningSlider;
-    juce::Slider* cutoffFreqSlider;
-    juce::Slider* resonanceSlider;
-    juce::Slider* envelopModSlider;
-    juce::Slider* decaySlider;
-    juce::Slider* accentSlider;
-    juce::Slider* volumeSlider;
+    std::unique_ptr<juce::Slider> waveformSlider;
+    std::unique_ptr<juce::Slider> tuningSlider;
+    std::unique_ptr<juce::Slider> cutoffFreqSlider;
+    std::unique_ptr<juce::Slider> resonanceSlider;
+    std::unique_ptr<juce::Slider> envelopModSlider;
+    std::unique_ptr<juce::Slider> decaySlider;
+    std::unique_ptr<juce::Slider> accentSlider;
+    std::unique_ptr<juce::Slider> volumeSlider;
     // MODs
-    juce::Slider* normalDecaySlider;
-    juce::Slider* accentDecaySlider;
-    juce::Slider* feedbackFilterSlider;
-    juce::Slider* softAttackSlider;
-    juce::Slider* accentSoftAttackSlider;
-    juce::Slider* slideTimeSlider;
-    juce::Slider* sqrDriverSlider;
-    SwitchButton* switchModButton;
-    SwitchLed* ledModButton;
+    std::unique_ptr<juce::Slider> normalDecaySlider;
+    std::unique_ptr<juce::Slider> accentDecaySlider;
+    std::unique_ptr<juce::Slider> feedbackFilterSlider;
+    std::unique_ptr<juce::Slider> softAttackSlider;
+    std::unique_ptr<juce::Slider> accentSoftAttackSlider;
+    std::unique_ptr<juce::Slider> slideTimeSlider;
+    std::unique_ptr<juce::Slider> sqrDriverSlider;
+    std::unique_ptr<SwitchButton> switchModButton;
+    std::unique_ptr<SwitchLed> ledModButton;
     // overdrive
-    juce::Slider* overdriveLevelSlider;
-    juce::Slider* overdriveDryWetSlider;
-    SwitchButton* switchOverdriveButton;
-    SwitchLed* ledOverdriveButton;
+    std::unique_ptr<juce::Slider> overdriveLevelSlider;
+    std::unique_ptr<juce::Slider> overdriveDryWetSlider;
+    std::unique_ptr<SwitchButton> switchOverdriveButton;
+    std::unique_ptr<SwitchLed> ledOverdriveButton;
 
     // declare the attchaments
     std::unique_ptr<SliderAttachment> waveformAttachment;
@@ -80,7 +80,7 @@ private:
     std::unique_ptr<SliderAttachment> overdriveDryWetAttachment;
     std::unique_ptr<ButtonAttachment> switchOverdriveButtonAttachment;
     // previous, next buttons and model name display component
-    OverdriveModelSelect* overdriveModelSelect;
+    std::unique_ptr<OverdriveModelSelect> overdriveModelSelect;
 
     // our value tree state
     juce::AudioProcessorValueTreeState& valueTreeState;


### PR DESCRIPTION
## Correctness cleanups: param-update race, GUI leaks, dead code

> ⚠️ **Stacked on #43** (`accent-soft-attack`). This branch is rebased on top of #43, so until #43 merges, the diff here includes #43's commits. **Please merge #43 first**, then this reduces to a single commit. The one conflict point (`updateNormalizer2`) was resolved in favour of #43's version.

Behavior-preserving correctness/hygiene pass on the plugin + open303 core. No intended change to the synth voicing.

### Changes
- **Parameter-update race** — `parameterChanged()` ran on the message/automation thread but called the open303 setters directly, rewriting filter/envelope coefficients while the audio thread was reading them inside `getSample()`. It now sets the (previously-declared-but-unused) `parametersNeedUpdate` flag; `processBlock` applies the current APVTS values via `updateOpen303Parameters()` on the audio thread. The overdrive **model load stays on the message thread** (it allocates / touches the filesystem and must not run in the audio callback).
- **GUI leaks** — sliders, switches, LEDs and the overdrive-model-select were raw-`new`'d and never deleted (leaked on every editor open/close). Converted to `std::unique_ptr`; the destructor now detaches each knob from its `KnobLookAndFeel` before those members are destroyed.
- **Dead normalizer code** — `updateNormalizer1()` computed `LeakyIntegrator::getNormalizer(...)` and immediately overwrote it with `1.0` (`// test`). Removed the dead call (the integrator runs unnormalized by design, now documented). `updateNormalizer2()` keeps #43's version, which documents why the accent capacitor is intentionally un-normalized.
- **Misleading comments** — dropped `// seems not to work yet` from the working env-mod path and the dead commented-out `idle` end-detection lines; clarified the `idle` guard; corrected the `NORMAL_DECAY` comment to state it drives the amplitude envelope (`setAmpDecay`), not the MEG.

### Integration with #43
`accentSoftAttack` (added by #43) is a devilfish-mod pot, so in the deferred model it's applied on the audio thread via `setDevilMod()` inside `updateOpen303Parameters()` — #43's `parameterChanged` else-if branch is no longer needed and was dropped; all its other plumbing (enum, param, `setParameter` case, `setDevilMod` handling, GUI knob) is preserved. The new knob was folded into the `unique_ptr` GUI and the destructor's look-and-feel detach loop.

