### PR TITLE
feat: reverse-gate mode (reverse-playback envelope shaping)

### DIFF
--- a/src/JC303.cpp
+++ b/src/JC303.cpp
@@ -52,6 +52,9 @@ JC303::JC303()
                                                         0.0f,
                                                         1.0f,
                                                         0.75f),
+            std::make_unique<juce::AudioParameterBool> ("reverseGate",
+                                                        "Reverse Gate",
+                                                        false),
             // MODs parameters
             std::make_unique<juce::AudioParameterFloat> ("normalDecay",
                                                         "Normal Decay",
@@ -116,6 +119,7 @@ JC303::JC303()
     decay = parameters.getRawParameterValue("decay");
     accent = parameters.getRawParameterValue("accent");
     volume = parameters.getRawParameterValue("volume");
+    reverseGate = parameters.getRawParameterValue("reverseGate");
     // MODs parameters
     switchModState = parameters.getRawParameterValue("switchModState");
     normalDecay = parameters.getRawParameterValue("normalDecay");
@@ -139,6 +143,7 @@ JC303::JC303()
     setParameter(DECAY, *decay);
     setParameter(ACCENT, *accent);
     setParameter(VOLUME, *volume);
+    setParameter(REVERSE_GATE, *reverseGate);
     setDevilMod(*switchModState);
     setParameter(NORMAL_DECAY, *normalDecay);
     setParameter(ACCENT_DECAY, *accentDecay);
@@ -169,6 +174,7 @@ JC303::JC303()
     parameters.addParameterListener("decay", this);
     parameters.addParameterListener("accent", this);
     parameters.addParameterListener("volume", this);
+    parameters.addParameterListener("reverseGate", this);
     parameters.addParameterListener("normalDecay", this);
     parameters.addParameterListener("accentDecay", this);
     parameters.addParameterListener("feedbackFilter", this);
@@ -192,6 +198,7 @@ JC303::~JC303()
     parameters.removeParameterListener("decay", this);
     parameters.removeParameterListener("accent", this);
     parameters.removeParameterListener("volume", this);
+    parameters.removeParameterListener("reverseGate", this);
     parameters.removeParameterListener("normalDecay", this);
     parameters.removeParameterListener("accentDecay", this);
     parameters.removeParameterListener("feedbackFilter", this);
@@ -232,6 +239,9 @@ void JC303::parameterChanged(const juce::String& parameterID, float newValue)
     }
     else if (parameterID == "volume") {
         setParameter(VOLUME, newValue);
+    }
+    else if (parameterID == "reverseGate") {
+        setParameter(REVERSE_GATE, newValue);
     }
     else if (parameterID == "switchModState") {
         setDevilMod(newValue > 0.5f);
@@ -310,6 +320,13 @@ void JC303::setParameter (Open303Parameters index, float value)
     case VOLUME:
         open303Core.setVolume(
             linToLin(value, 0.0, 1.0, -60.0,      0.0)
+        );
+        break;
+    case REVERSE_GATE:
+        // 0 = normal note, 1 = fully time-reversed amp/filter/accent contour (swell up then cut).
+        // Swell timing follows the Decay knob (the main envelope's time constant).
+        open303Core.setReverseGate(
+            linToLin(value, 0.0, 1.0,   0.0,      1.0)
         );
         break;
 
@@ -548,7 +565,14 @@ void JC303::processBlock (juce::AudioBuffer<float>& buffer,
     juce::ScopedNoDenormals noDenormals;
     auto currentSample = 0;
     const auto numSamples = buffer.getNumSamples();
-    
+
+    // pass the host tempo to the core so the reverse-gate can snap its length prediction to the grid
+    if (auto* ph = getPlayHead())
+        if (auto pos = ph->getPosition())
+            if (auto bpm = pos->getBpm())
+                open303Core.setReverseTempo(*bpm);
+
+
     // clear buffer
     auto totalNumInputChannels  = getTotalNumInputChannels();
     auto totalNumOutputChannels = getTotalNumOutputChannels();

--- a/src/JC303.h
+++ b/src/JC303.h
@@ -19,6 +19,7 @@ enum Open303Parameters
   DECAY,
   ACCENT,
   VOLUME,
+  REVERSE_GATE,
   // MODs
   SWITCH_MOD,
   NORMAL_DECAY,
@@ -114,6 +115,7 @@ private:
     std::atomic<float>* decay = nullptr;
     std::atomic<float>* accent = nullptr;
     std::atomic<float>* volume = nullptr;
+    std::atomic<float>* reverseGate = nullptr;
     // MODs
     std::atomic<float>* switchModState = nullptr;
     std::atomic<float>* normalDecay = nullptr;

--- a/src/dsp/open303/rosic_Open303.cpp
+++ b/src/dsp/open303/rosic_Open303.cpp
@@ -13,6 +13,24 @@ Open303::Open303()
   level            =   -12.0;
   levelByVel       =    12.0;
   accent           =     0.0;
+  reverseGate      =     0.0;
+  reversePhase     =     0.0;
+  reverseLength    = 44100.0;  // 1s placeholder until the first note sets it (see triggerNote)
+  reverseMeasured  =     0.0;
+  reverseHistPos   =       0;
+  reverseHistCount =       0;
+  reverseTempoBpm  =     0.0;
+  for(int i=0; i<8; i++) reverseHist[i] = 0.0;
+  reverseLastOnPhase =   0.0;
+  reverseStep      =     0.0;
+  reverseShape     =     3.5;
+  reverseDen       = exp(reverseShape) - 1.0;
+  reverseShapeMain =     3.5;
+  reverseFreqFrom  =   440.0;
+  reverseLogRatio  =     0.0;
+  reverseGlideBase =     0.0;
+  reverseInstFreq  =   440.0;
+  reverseSwellNow  =     0.0;
   slideTime        =    60.0;
   cutoff           =  1000.0;
   envUpFraction    =     2.0/3.0;
@@ -243,11 +261,104 @@ void Open303::triggerNote(int noteNumber, bool hasAccent)
   mainEnv.trigger();
   ampEnv.noteOn(true, noteNumber, 64);
   idle = false;
+
+  // fresh (non-slide) note: no reversed portamento glide
+  reverseFreqFrom  = oscFreq;
+  reverseLogRatio  = 0.0;
+  reverseGlideBase = 0.0;
+  reverseInstFreq  = oscFreq;
+  reverseSwellNow  = 0.0;
+
+  // reset the reverse-gate swell and predict its length so its peak lands at the note's end. In
+  // sequencer mode the step length is known exactly; otherwise we repeat the previous note/group's
+  // measured length (steady patterns land dead-on), falling back to a Decay-derived time.
+  reversePhase       = 0.0;
+  reverseLastOnPhase = 0.0;
+  reverseStep        = 0.0;
+  if( sequencer.getSequencerMode() != AcidSequencer::OFF && sequencer.isRunning() )
+    reverseLength = sequencer.getStepLengthInSamples();
+  else
+    reverseLength = predictReverseLength();
+  updateReverseShape();
+}
+
+double Open303::predictReverseLength()
+{
+  // first note (no history yet): fall back to a Decay-derived time
+  if( reverseHistCount == 0 )
+    return 0.001 * mainEnv.getDecayTimeConstant() * sampleRate * 2.5;
+
+  // short-biased estimate: a low percentile of recent measured lengths. Because the swell holds at
+  // its peak (reverseHoldAt in getSample), UNDER-predicting is graceful (peak lands early, then
+  // holds) while OVER-predicting starves a short note of its swell - so we deliberately lean short
+  // to keep varied patterns (e.g. a short note after a long one) from dropping out.
+  double sorted[8];
+  int n = reverseHistCount;
+  for(int i=0; i<n; i++) sorted[i] = reverseHist[i];
+  for(int i=0; i<n-1; i++)                 // tiny insertion sort (n <= 8)
+    for(int j=i+1; j<n; j++)
+      if( sorted[j] < sorted[i] ) { double t=sorted[i]; sorted[i]=sorted[j]; sorted[j]=t; }
+  double base = sorted[n/4];               // ~25th percentile
+
+  // tempo snap: quantize to the nearest 16th-note multiple (min one 16th) when the host tempo is
+  // known - acid lines are grid-locked, so this removes measurement jitter and lands the peak on
+  // the musical grid.
+  if( reverseTempoBpm > 0.0 )
+  {
+    double t16 = sampleRate * 60.0 / reverseTempoBpm / 4.0;   // one 16th note, in samples
+    if( t16 >= 1.0 )
+    {
+      double mult = floor(base / t16 + 0.5);
+      if( mult < 1.0 ) mult = 1.0;
+      base = mult * t16;
+    }
+  }
+  return base;
+}
+
+void Open303::updateReverseShape()
+{
+  if( reverseLength < 1.0 )
+    reverseLength = 1.0;
+
+  // auto-shape for a faithful reversal: the time-reverse of the forward amplitude decay e^(-t/tau)
+  // over a note of length L is the floored swell e^(K*(r-1)) with K = L/tau (see getSample). So set
+  // the swell shape from the note length divided by the amp-envelope decay time - this makes the
+  // reverse gate match an actual "played backwards" note regardless of tempo or decay setting.
+  // The upper clamp bounds the swell's head floor at e^-K (~-22 dB at K=2.5): this keeps reverse
+  // notes as loud as forward ones and guarantees a note that ends before the predicted
+  // reverseLength still rises well above silence instead of sounding "skipped".
+  double ampDecaySamples = 0.001 * ampEnv.getDecay() * sampleRate;
+  if( ampDecaySamples < 1.0 )
+    ampDecaySamples = 1.0;
+  double k = reverseLength / ampDecaySamples;
+  if( k < 0.1 ) k = 0.1;    // keep the glide normalizer (e^k - 1) well-conditioned
+  if( k > 2.5 ) k = 2.5;    // head floor >= e^-2.5: loudness/audibility guarantee
+  reverseShape = k;
+  reverseDen   = exp(k) - 1.0;   // cached normalizer for the swell
+
+  // the reversed filter/accent sweep mirrors the *main* (filter) envelope's decay, so the Decay
+  // knob shapes the reverse sweep just like it shapes the forward one. A wider clamp keeps more
+  // sweep drama; audibility is governed by the amplitude swell above, not by this one.
+  double mainDecaySamples = 0.001 * mainEnv.getDecayTimeConstant() * sampleRate;
+  if( mainDecaySamples < 1.0 )
+    mainDecaySamples = 1.0;
+  double km = reverseLength / mainDecaySamples;
+  if( km < 0.1 ) km = 0.1;
+  if( km > 4.0 ) km = 4.0;
+  reverseShapeMain = km;
 }
 
 void Open303::slideToNote(int noteNumber, bool hasAccent)
 {
   oscFreq = pitchToFreq(noteNumber, tuning);
+
+  // inverse portamento: glide from wherever the pitch currently is toward the new note, spanning the
+  // remaining swell so it arrives during the note's audible tail (see getSample). Anchoring to the
+  // current pitch and current swell keeps the glide continuous even across mid-group slides.
+  reverseFreqFrom  = reverseInstFreq;
+  reverseGlideBase = reverseSwellNow;
+  reverseLogRatio  = log(oscFreq / reverseFreqFrom);
 
   if( hasAccent )
   {
@@ -262,6 +373,23 @@ void Open303::slideToNote(int noteNumber, bool hasAccent)
     ampEnv.setRelease(normalAmpRelease);
   }
   idle = false;
+
+  // A slide extends the current note into a tied group, so the reverse swell must keep climbing
+  // toward the (still unknown) group end rather than peaking at the first note. We don't reset the
+  // phase; instead we measure the note-on spacing and project the horizon at least one step past the
+  // latest note. Only adopt the projection when we have no better prediction (first group) or when
+  // the group is outlasting the predicted length - this keeps the swell from plateauing early while
+  // preserving an accurate cross-group prediction for steady patterns.
+  double step = reversePhase - reverseLastOnPhase;
+  reverseLastOnPhase = reversePhase;
+  if( step > 0.0 )
+    reverseStep = step;
+  double projected = reversePhase + reverseStep;
+  if( reverseMeasured <= 0.0 || projected > reverseLength )
+  {
+    reverseLength = projected;
+    updateReverseShape();
+  }
 }
 
 void Open303::releaseNote(int noteNumber)
@@ -273,6 +401,14 @@ void Open303::releaseNote(int noteNumber)
   {
     //filterEnvelope.noteOff();
     ampEnv.noteOff();
+    // remember how long this note lasted, to predict the next note's reverse-swell length:
+    if( reversePhase > 0.0 )
+    {
+      reverseMeasured = reversePhase;
+      reverseHist[reverseHistPos] = reversePhase;   // feed the prediction history ring buffer
+      reverseHistPos = (reverseHistPos + 1) % 8;
+      if( reverseHistCount < 8 ) reverseHistCount++;
+    }
   }
   else
   {

--- a/src/dsp/open303/rosic_Open303.h
+++ b/src/dsp/open303/rosic_Open303.h
@@ -70,6 +70,13 @@ namespace rosic
     /** Sets the accent (in percent).  */
     void setAccent(double newAccent);
 
+    /** Sets the reverse-gate depth (0...1). At 0 the note plays normally. As it approaches 1, the
+    amplitude, filter and accent contours are progressively flipped in time, so the note swells up
+    from silence and the filter opens toward the note's end (then cuts on the next trigger) - it
+    sounds like the note is played backwards. The swell duration follows the Decay setting (the main
+    envelope's time constant), so it needs no separate time control. */
+    void setReverseGate(double newReverseGate) { reverseGate = clip(newReverseGate, 0.0, 1.0); }
+
     /** Sets the master volume level (in dB). */
     void setVolume(double newVolume);     
 
@@ -165,6 +172,13 @@ namespace rosic
 
     /** Returns the accent (in percent). */
     double getAccent() const { return 100.0 * accent; }
+
+    /** Returns the reverse-gate depth (0...1). */
+    double getReverseGate() const { return reverseGate; }
+
+    /** Sets the host tempo (BPM) so the predicted reverse-swell length can be snapped to the musical
+    16th-note grid. Pass 0 (or a non-positive value) when no tempo is available. */
+    void setReverseTempo(double bpm) { reverseTempoBpm = (bpm > 0.0) ? bpm : 0.0; }
 
     /** Returns the master volume level (in dB). */
     double getVolume() const { return level; }
@@ -268,6 +282,14 @@ namespace rosic
     /** Sets the decay-time of the main envelope and updates the normalizers n1, n2 accordingly. */
     void setMainEnvDecay(double newDecay);
 
+    /** Recomputes the reverse-swell shape (reverseShape) from the current reverseLength and the
+    amp-envelope decay, so the swell stays a faithful reversal as the predicted length changes. */
+    void updateReverseShape();
+
+    /** Predicts the current note's length (in samples) for the reverse swell: a short-biased low
+    percentile of recent measured note lengths, optionally snapped to the host's 16th-note grid. */
+    double predictReverseLength();
+
     void calculateEnvModScalerAndOffset();
 
     /** Updates the normalizer n1 according to the time-constant of rc1 and the decay-time of the
@@ -287,6 +309,25 @@ namespace rosic
     double level;            // master volume level (in dB)
     double levelByVel;       // velocity dependence of the level (in dB)
     double accent;           // scales all "byVel" parameters
+    double reverseGate;      // 0...1 depth for the reverse-gate effect (see setReverseGate)
+    double reversePhase;     // samples elapsed since the note trigger (drives the reverse swell)
+    double reverseLength;    // predicted note length in samples; the reverse swell peaks here
+    double reverseMeasured;  // duration of the previous note/group, used to predict reverseLength
+    double reverseLastOnPhase; // reversePhase at the most recent note-on within the current group
+    double reverseStep;      // samples between consecutive note-ons in the current tied group
+    double reverseShape;     // back-loadedness of the reverse swell, auto-set in updateReverseShape()
+    double reverseShapeMain; // back-loadedness of the reversed filter/accent sweep, derived from
+                             // the main (filter) envelope's decay in updateReverseShape()
+    double reverseDen;       // e^reverseShape - 1, cached normalizer for the swell
+    double reverseFreqFrom;  // pitch the reversed portamento glides from (Hz)
+    double reverseLogRatio;  // ln(targetFreq / reverseFreqFrom); 0 for non-slide notes
+    double reverseGlideBase; // swell value when the current glide started (re-anchor, jump-free slides)
+    double reverseInstFreq;  // last instantaneous oscillator pitch (Hz), for glide continuity
+    double reverseSwellNow;  // most recent swell value, read by slideToNote to re-anchor the glide
+    double reverseHist[8];   // ring buffer of recent measured note lengths (samples), for prediction
+    int    reverseHistPos;   // write index into reverseHist
+    int    reverseHistCount; // number of valid entries in reverseHist (<= 8)
+    double reverseTempoBpm;  // host tempo in BPM (0 = unknown); snaps prediction to the 16th grid
     double slideTime;        // the time to slide from one note to another (in ms)
     double cutoff;           // nominal cutoff frequency of the filter
     double envMod;           // strength of the envelope modulation in percent
@@ -357,28 +398,87 @@ namespace rosic
       }
     }
 
+    // --- reverse-gate: synthesize a genuinely time-reversed contour -------------------------------
+    // Playing a note backwards means the amplitude/filter grow as a *back-loaded* exponential: they
+    // stay quiet for most of the note, then swell rapidly to a peak right at the end, where the
+    // original attack transient becomes an abrupt cut. We drive that swell from a phase counter that
+    // reaches 1 at 'reverseLength' samples after the trigger - which triggerNote() sets to the note's
+    // (predicted) length - so the peak lands exactly at the note's end. reverseShape sets how
+    // back-loaded the curve is; reverseDen == e^reverseShape - 1 normalizes it to 0..1. Computed
+    // before the oscillator frequency because in reverse mode the swell also shapes the pitch glide.
+    double mainEnvFwd = mainEnv.getSample();  // forward main envelope: decays 1 -> 0
+    double rPos  = reversePhase / reverseLength;                  // 0..1 over the note, then clamped
+    if( rPos > 1.0 ) rPos = 1.0;
+    // The swell completes slightly early (at reverseHoldAt of the predicted length) and then HOLDS
+    // at the peak until the cut. This concentrates energy at full level right before the end-cut
+    // (punch), and protects against over-predicted note lengths starving the note of its peak.
+    const double reverseHoldAt = 0.85;
+    double rSw = rPos * (1.0/reverseHoldAt);
+    if( rSw > 1.0 ) rSw = 1.0;
+    // Amplitude swell: the exact time-reverse of the forward decay e^(-t/tau) over a note of
+    // length L is e^(K*(r-1)) with K = L/tau - a back-loaded exponential with a *floor* of e^-K at
+    // the head, NOT silence. Using this floored form (instead of the 0-normalized
+    // (e^(K*r)-1)/(e^K-1)) preserves the forward note's RMS by mirror symmetry, so reverse mode is
+    // as loud as forward, and guarantees every gated note is audible even when the predicted
+    // reverseLength overshoots the actual note (no more "skipped" short notes).
+    double swellAmp  = exp(reverseShape*(rSw - 1.0));
+    // Filter/accent swell: same floored form, but shaped by the *main* (filter) envelope's decay
+    // (reverseShapeMain), so the reversed cutoff sweep mirrors what the Decay knob does forwards
+    // and opens fully into the peak.
+    double swellMain = exp(reverseShapeMain*(rSw - 1.0));
+    // filter-sweep floor: keep the reversed cutoff from starting fully closed. For a full-length note
+    // this only lifts the quiet head (masked by the low amplitude there); for a note cut short by an
+    // over-prediction it keeps the audible portion from sounding dull - self-proportional via the amp
+    // gate. Costs a little sweep drama; set to 0 for the purest closed->open sweep.
+    const double reverseFilterFloor = 0.15;
+    if( swellMain < reverseFilterFloor ) swellMain = reverseFilterFloor;
+    // 0-based normalized swell, kept as the pitch-glide driver (glide anchoring expects 0..1):
+    double swell = (exp(reverseShape*rSw) - 1.0) / reverseDen;
+    reversePhase += 1.0;
+    reverseSwellNow = swell;   // slideToNote() reads this to re-anchor the pitch glide
+    // gate the amplitude swell to the held note so it cuts at note-off / rests instead of holding:
+    double revAmp = ampEnv.isNoteOn() ? swellAmp : 0.0;
+
     // calculate instantaneous oscillator frequency and set up the oscillator:
     double instFreq = pitchSlewLimiter.getSample(oscFreq);
+    if( reverseGate > 0.0 )
+    {
+      // inverse portamento: the forward slew glides old->new at the note's silent head, so in reverse
+      // mode it is inaudible. Instead glide from the current pitch to the target along the remaining
+      // swell so it arrives during the audible tail - the reversed timing. The glide is re-anchored to
+      // where the swell was when it started (reverseGlideBase), so mid-group slides never jump.
+      double span     = 1.0 - reverseGlideBase;
+      double gp       = (span > 1.0e-3) ? (swell - reverseGlideBase) / span : 1.0;
+      if( gp < 0.0 ) gp = 0.0;
+      if( gp > 1.0 ) gp = 1.0;
+      double glideFreq = reverseFreqFrom * exp(gp * reverseLogRatio);
+      instFreq = instFreq + reverseGate * (glideFreq - instFreq);
+    }
+    reverseInstFreq = instFreq;   // remember current pitch so a following slide can glide from here
     oscillator.setFrequency(instFreq*pitchWheelFactor);
     oscillator.calculateIncrement();
 
-    // calculate instantaneous cutoff frequency from the nominal cutoff and all its modifiers and 
-    // set up the filter:
-    double mainEnvOut = mainEnv.getSample();
+    // filter- & accent-modulation driver: crossfade forward (1->0) to the reversed main-env swell
+    // (e^-Km -> 1) so the cutoff opens on the mirrored curve of the forward Decay sweep and the
+    // accent emphasis lands on the peak, mirroring reversed audio.
+    double mainEnvOut = mainEnvFwd + reverseGate * (swellMain - mainEnvFwd);
+
     double tmp1       = n1 * rc1.getSample(mainEnvOut);
     double tmp2       = 0.0;
     if( accentGain > 0.0 )
       tmp2 = mainEnvOut;
-    tmp2 = n2 * rc2.getSample(tmp2);  
+    tmp2 = n2 * rc2.getSample(tmp2);
     tmp1 = envScaler * ( tmp1 - envOffset );  // seems not to work yet
     tmp2 = accentGain*tmp2;
     double instCutoff = cutoff * pow(2.0, tmp1+tmp2);
     filter.setCutoff(instCutoff);
 
-    double ampEnvOut = ampEnv.getSample();
-    //ampEnvOut += 0.45*filterEnvOut + accentGain*6.8*filterEnvOut; 
+    // amplitude contour: crossfade the forward amp envelope with the reversed swell.
+    double ampFwd    = ampEnv.getSample();
+    double ampEnvOut = ampFwd + reverseGate * (revAmp - ampFwd);
+    //ampEnvOut += 0.45*filterEnvOut + accentGain*6.8*filterEnvOut;
     if( ampEnv.isNoteOn() )
-      ampEnvOut += 0.45*mainEnvOut + accentGain*4.0*mainEnvOut; 
+      ampEnvOut += 0.45*mainEnvOut + accentGain*4.0*mainEnvOut;
     ampEnvOut = ampDeClicker.getSample(ampEnvOut);
 
     // oversampled calculations:

--- a/src/gui/amadeusp/Gui.cpp
+++ b/src/gui/amadeusp/Gui.cpp
@@ -13,6 +13,9 @@ JC303Editor::JC303Editor (JC303& p, juce::AudioProcessorValueTreeState& vts)
     addAndMakeVisible(envelopModSlider = createKnob("medium"));
     addAndMakeVisible(decaySlider = createKnob("medium"));
     addAndMakeVisible(accentSlider = createKnob("medium"));
+    // reverse gate on/off toggle
+    addAndMakeVisible(switchReverseButton = createSwitch());
+    addAndMakeVisible(ledReverseButton = createLed("reverseGate"));
     // MODs row
     addAndMakeVisible(normalDecaySlider = createKnob("small"));
     addAndMakeVisible(accentDecaySlider = createKnob("small"));
@@ -44,6 +47,8 @@ JC303Editor::JC303Editor (JC303& p, juce::AudioProcessorValueTreeState& vts)
     decayAttachment.reset (new SliderAttachment (valueTreeState, "decay", *decaySlider));
     accentAttachment.reset (new SliderAttachment (valueTreeState, "accent", *accentSlider));
     volumeAttachment.reset (new SliderAttachment (valueTreeState, "volume", *volumeSlider));
+    // reverse gate on/off toggle
+    switchReverseButtonAttachment.reset(new ButtonAttachment(valueTreeState, "reverseGate", *switchReverseButton));
     // MODs row
     normalDecayAttachment.reset(new SliderAttachment(valueTreeState, "normalDecay", *normalDecaySlider));
     accentDecayAttachment.reset(new SliderAttachment(valueTreeState, "accentDecay", *accentDecaySlider));
@@ -83,6 +88,11 @@ void JC303Editor::paint (juce::Graphics& g)
 
     // Draw the image to fill the entire component area
     g.drawImage (background, getLocalBounds().toFloat());
+
+    // Label for the reverse-gate toggle (no baked-in text on the skin for it)
+    g.setColour (juce::Colours::black);
+    g.setFont (12.0f);
+    g.drawText ("REVERSE", 222, 344, 62, 16, juce::Justification::centredLeft, false);
 }
 
 void JC303Editor::resized()
@@ -161,6 +171,9 @@ void JC303Editor::setControlsLayout()
     pair<int, int> softAttackLocation = {330, 273};
     pair<int, int> slideTimeLocation = {391, 273};
     pair<int, int> sqrDriverLocation = {452, 273};
+    // reverse gate toggle (bottom gray margin, under the Normal/Accent Decay knobs)
+    pair<int, int> reverseLedLocation = {150, 344};
+    pair<int, int> reverseSwitchLocation = {170, 343};
     // MODs switch
     pair<int, int> switchLocation = {52, 273};
     pair<int, int> modLedLocation = {82, 243};
@@ -185,6 +198,9 @@ void JC303Editor::setControlsLayout()
     envelopModSlider->setBounds(envelopeLocation.first, envelopeLocation.second, sliderMediumSize, sliderMediumSize);
     decaySlider->setBounds(decayLocation.first, decayLocation.second, sliderMediumSize, sliderMediumSize);
     accentSlider->setBounds(accentLocation.first, accentLocation.second, sliderMediumSize, sliderMediumSize);
+    // reverse gate toggle
+    switchReverseButton->setBounds(reverseSwitchLocation.first, reverseSwitchLocation.second, switchWidth, switchHeight);
+    ledReverseButton->setBounds(reverseLedLocation.first, reverseLedLocation.second, ledWidth, ledHeight);
     // MODs, small knobs, switch
     normalDecaySlider->setBounds(normalDecayLocation.first, normalDecayLocation.second, sliderSmallSize, sliderSmallSize);
     accentDecaySlider->setBounds(accentDecayLocation.first, accentDecayLocation.second, sliderSmallSize, sliderSmallSize);

--- a/src/gui/amadeusp/Gui.h
+++ b/src/gui/amadeusp/Gui.h
@@ -41,6 +41,9 @@ private:
     juce::Slider* decaySlider;
     juce::Slider* accentSlider;
     juce::Slider* volumeSlider;
+    // reverse gate toggle
+    SwitchButton* switchReverseButton;
+    SwitchLed* ledReverseButton;
     // MODs
     juce::Slider* normalDecaySlider;
     juce::Slider* accentDecaySlider;
@@ -65,6 +68,8 @@ private:
     std::unique_ptr<SliderAttachment> decayAttachment;
     std::unique_ptr<SliderAttachment> accentAttachment;
     std::unique_ptr<SliderAttachment> volumeAttachment;
+    // reverse gate toggle
+    std::unique_ptr<ButtonAttachment> switchReverseButtonAttachment;
     // MODs
     std::unique_ptr<SliderAttachment> normalDecayAttachment;
     std::unique_ptr<SliderAttachment> accentDecayAttachment;


### PR DESCRIPTION
## What

Adds a MIDI-learnable on/off **Reverse Gate** toggle that reshapes each note so it sounds like it was recorded and played backwards.

- **Amplitude, filter cutoff and accent** contours are time-reversed into a back-loaded swell that peaks at the note's end and cuts sharply.
- **Auto shape:** the swell shape is derived per note as note-length ÷ amp-decay — the mathematically faithful reversal at any tempo/decay. A floored mirror plus an 85% peak-hold keep every reversed note as loud as the forward note (no volume loss).
- **Length prediction:** the note length is predicted from a short-biased percentile of recent note lengths and, when the host reports tempo, snapped to the 16th-note grid — so short/staccato notes don't drop out.
- **Ties/slides:** a legato group is treated as one reversed note, with **inverse portamento** — the pitch glides into the target during the audible tail (reversed timing), re-anchored per slide so it never jumps.
- **GUI:** an LED on/off toggle in the amadeusp skin, in the gray margin under the Normal/Accent Decay knobs (reuses the existing switch/LED components).

`reverseGate = 0` is byte-identical to the previous output, so the feature is fully bypassed when off.
